### PR TITLE
운영 페이지 챌린지 초기화 기능 (/admin/init)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ challenge_data.dat
 challenge_admin.xlsx
 firstPlayer.txt
 groupRoster.txt
+settings.json
+
+# 샘플 CSV (관리자 테스트용)
+sample_participants*.csv
 
 # 환경변수
 .env

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 코딩 에이전트 릴레이 설치 챌린지 - Flask 웹 애플리케이션
 """
 
+import json
 import os
 import secrets
 import string
@@ -13,6 +14,28 @@ from flask import (Flask, render_template, request, redirect, url_for,
                    session, flash, send_file, jsonify, abort, make_response)
 from models import db, Group, Runner, AttemptLog
 import config
+
+
+# ============================================================
+# 설정 파일 (초기화 마법사에서 쓰이는 운영 옵션)
+# ============================================================
+SETTINGS_PATH = os.path.join(os.path.dirname(__file__), 'settings.json')
+DEFAULT_SETTINGS = {'show_individual_ranking': True}
+
+
+def _read_settings() -> dict:
+    try:
+        with open(SETTINGS_PATH, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        return {**DEFAULT_SETTINGS, **data}
+    except (FileNotFoundError, json.JSONDecodeError):
+        return dict(DEFAULT_SETTINGS)
+
+
+def _write_settings(data: dict) -> None:
+    merged = {**DEFAULT_SETTINGS, **data}
+    with open(SETTINGS_PATH, 'w', encoding='utf-8') as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
 
 
 def create_app():
@@ -389,10 +412,13 @@ def get_individual_rankings(limit=20):
 @app.route('/leaderboard')
 def leaderboard():
     rankings = get_group_rankings()
-    individuals = get_individual_rankings(limit=10)
+    settings = _read_settings()
+    show_individual = settings.get('show_individual_ranking', True)
+    individuals = get_individual_rankings(limit=10) if show_individual else []
     return render_template('leaderboard.html',
                            rankings=rankings,
-                           individuals=individuals)
+                           individuals=individuals,
+                           show_individual=show_individual)
 
 
 @app.route('/guide')
@@ -911,6 +937,9 @@ def admin_init_commit():
             'order':   int(p.get('order', 0)),
         })
 
+    # 운영 옵션 (리더보드 개인 랭킹 공개 여부 등)
+    show_individual = bool(data.get('show_individual_ranking', True))
+
     # 6) init_database 실행 — 세션/엔진을 먼저 닫아야 Windows에서 DB 파일 삭제 가능
     db.session.remove()
     db.engine.dispose()
@@ -929,6 +958,12 @@ def admin_init_commit():
             'error_code': 'INTERNAL',
             'message': f'초기화 실패: {type(e).__name__}: {e}',
         }), 500
+
+    # 7) 운영 옵션 저장 (DB 초기화와 독립)
+    try:
+        _write_settings({'show_individual_ranking': show_individual})
+    except OSError:
+        pass  # 파일 쓰기 실패해도 초기화 자체는 성공으로 간주
 
     return jsonify({
         'ok': True,

--- a/app.py
+++ b/app.py
@@ -665,6 +665,300 @@ def admin_logout():
 
 
 # ============================================================
+# /admin/init - 챌린지 초기화 마법사
+# ============================================================
+INIT_N_MIN, INIT_N_MAX = 2, 500
+INIT_G_MIN, INIT_G_MAX = 2, 50
+
+
+def _parse_csv_text(csv_text: str) -> tuple[list[dict], list[dict]]:
+    """CSV 텍스트 파싱. 쉼표·탭 둘 다 허용, 헤더 자동 감지.
+    반환: (participants, errors) — errors는 파싱 수준 오류만 (행 단위 검증은 상위에서)
+    """
+    participants: list[dict] = []
+    errors: list[dict] = []
+
+    lines = [ln for ln in csv_text.splitlines() if ln.strip()]
+    if not lines:
+        return participants, [{'row': 0, 'message': 'CSV가 비어 있습니다.'}]
+
+    def split_fields(line: str) -> list[str]:
+        # 탭이 있으면 탭 우선, 아니면 쉼표
+        if '\t' in line:
+            return [c.strip() for c in line.split('\t')]
+        return [c.strip() for c in line.split(',')]
+
+    header_fields = split_fields(lines[0])
+    lower = [h.lower() for h in header_fields]
+    has_header = any(
+        key in lower or key in header_fields
+        for key in ('knox_id', 'knox-id', 'name', '이름')
+    )
+
+    if has_header:
+        # 헤더 기반 컬럼 매핑
+        col_knox = None
+        col_name = None
+        for i, h in enumerate(header_fields):
+            hl = h.lower()
+            if hl in ('knox_id', 'knox-id'):
+                col_knox = i
+            elif hl in ('name', '이름'):
+                col_name = i
+        if col_knox is None or col_name is None:
+            return participants, [{
+                'row': 1,
+                'message': '헤더에 knox_id, name 컬럼이 모두 필요합니다.',
+            }]
+        data_lines = lines[1:]
+        row_offset = 2  # 1 = 헤더, 2부터 데이터
+    else:
+        col_knox, col_name = 0, 1
+        data_lines = lines
+        row_offset = 1
+
+    for i, line in enumerate(data_lines):
+        fields = split_fields(line)
+        if len(fields) < max(col_knox, col_name) + 1:
+            errors.append({'row': row_offset + i, 'message': '컬럼 부족'})
+            continue
+        knox_id = fields[col_knox].strip().lower()
+        name = fields[col_name].strip()
+        if not knox_id:
+            errors.append({'row': row_offset + i, 'message': '빈 knox_id'})
+            continue
+        if not name:
+            errors.append({'row': row_offset + i, 'message': '빈 name'})
+            continue
+        participants.append({'knox_id': knox_id, 'name': name})
+
+    return participants, errors
+
+
+def _compute_group_sizes(total: int, group_count: int) -> list[int]:
+    from init_db import compute_group_sizes as _c
+    return _c(total, group_count)
+
+
+def _current_problem_pool_size() -> int:
+    """현재 challenge_data.dat(풀)에 몇 개의 문제가 들어있는지 기록.
+    실제 풀 크기 계산은 비용이 커서 메타 정보를 쓰거나 제너레이터 호출 필요.
+    여기서는 DEFAULT_TOTAL_PROBLEMS 기준으로 안내용 반환."""
+    from generate_challenge import DEFAULT_TOTAL_PROBLEMS
+    return DEFAULT_TOTAL_PROBLEMS
+
+
+@app.route('/admin/init')
+@admin_required
+def admin_init():
+    return render_template(
+        'admin_init.html',
+        n_min=INIT_N_MIN, n_max=INIT_N_MAX,
+        g_min=INIT_G_MIN, g_max=INIT_G_MAX,
+        default_n=130, default_g=10,
+        problem_pool_size=_current_problem_pool_size(),
+    )
+
+
+@app.route('/admin/init/parse', methods=['POST'])
+@admin_required
+def admin_init_parse():
+    data = request.get_json(silent=True) or {}
+    csv_text = (data.get('csv_text') or '').strip()
+    try:
+        total_n = int(data.get('total_n', 0))
+        group_count = int(data.get('group_count', 0))
+    except (TypeError, ValueError):
+        return jsonify({'ok': False, 'errors': [{'row': 0, 'message': 'N/G 정수 아님'}]}), 400
+
+    # N, G 범위 검증
+    errors: list[dict] = []
+    if not (INIT_N_MIN <= total_n <= INIT_N_MAX):
+        errors.append({'row': 0, 'message': f'전체 인원수는 {INIT_N_MIN}~{INIT_N_MAX} 범위여야 합니다.'})
+    if not (INIT_G_MIN <= group_count <= INIT_G_MAX):
+        errors.append({'row': 0, 'message': f'조 수는 {INIT_G_MIN}~{INIT_G_MAX} 범위여야 합니다.'})
+    if group_count > total_n:
+        errors.append({'row': 0, 'message': '조 수가 전체 인원수보다 클 수 없습니다.'})
+    if errors:
+        return jsonify({'ok': False, 'errors': errors, 'duplicates': []}), 400
+
+    # CSV 파싱
+    participants, parse_errors = _parse_csv_text(csv_text)
+    if parse_errors:
+        return jsonify({'ok': False, 'errors': parse_errors, 'duplicates': []}), 400
+
+    # 중복 knox_id 검사
+    seen: dict[str, int] = {}
+    duplicates: list[str] = []
+    for idx, p in enumerate(participants, start=1):
+        if p['knox_id'] in seen:
+            if p['knox_id'] not in duplicates:
+                duplicates.append(p['knox_id'])
+        else:
+            seen[p['knox_id']] = idx
+    if duplicates:
+        return jsonify({
+            'ok': False,
+            'errors': [{'row': 0, 'message': f'중복 knox_id: {", ".join(duplicates)}'}],
+            'duplicates': duplicates,
+        }), 400
+
+    # 행 수 vs N 경고 (차단은 아님 — 상위에서 선택)
+    warnings: list[str] = []
+    if len(participants) != total_n:
+        warnings.append(
+            f'CSV 행 수({len(participants)})가 전체 인원수({total_n})와 다릅니다. '
+            '앞 N명만 사용하거나 부족분은 extra###로 채워집니다.'
+        )
+        # 자동 조정
+        if len(participants) > total_n:
+            participants = participants[:total_n]
+        else:
+            for i in range(len(participants) + 1, total_n + 1):
+                participants.append({'knox_id': f'extra{i:03d}', 'name': f'추가참가자{i:03d}'})
+
+    group_sizes = _compute_group_sizes(total_n, group_count)
+    return jsonify({
+        'ok': True,
+        'participants': participants,
+        'group_sizes': group_sizes,
+        'problem_pool_size': _current_problem_pool_size(),
+        'warnings': warnings,
+    })
+
+
+@app.route('/admin/init/commit', methods=['POST'])
+@admin_required
+def admin_init_commit():
+    data = request.get_json(silent=True) or {}
+
+    # 1) INIT 확인 문자열
+    if (data.get('confirm') or '') != 'INIT':
+        return jsonify({
+            'ok': False,
+            'error_code': 'CONFIRM_MISMATCH',
+            'message': 'INIT 을 정확히 입력해야 합니다.',
+        }), 400
+
+    # 2) 파라미터 검증
+    try:
+        group_count = int(data.get('group_count', 0))
+    except (TypeError, ValueError):
+        return jsonify({'ok': False, 'error_code': 'VALIDATION', 'message': 'group_count 정수 아님'}), 400
+    group_sizes = data.get('group_sizes') or []
+    if not isinstance(group_sizes, list) or len(group_sizes) != group_count:
+        return jsonify({'ok': False, 'error_code': 'VALIDATION', 'message': 'group_sizes 불일치'}), 400
+    try:
+        group_sizes = [int(x) for x in group_sizes]
+    except (TypeError, ValueError):
+        return jsonify({'ok': False, 'error_code': 'VALIDATION', 'message': 'group_sizes 정수 아님'}), 400
+
+    ordered = data.get('ordered_participants') or []
+    if not isinstance(ordered, list) or len(ordered) != sum(group_sizes):
+        return jsonify({'ok': False, 'error_code': 'VALIDATION',
+                        'message': f'ordered_participants 길이({len(ordered)}) != sum(group_sizes)({sum(group_sizes)})'}), 400
+
+    total_n = len(ordered)
+    if not (INIT_N_MIN <= total_n <= INIT_N_MAX):
+        return jsonify({'ok': False, 'error_code': 'VALIDATION',
+                        'message': f'전체 인원 {INIT_N_MIN}~{INIT_N_MAX} 범위 벗어남'}), 400
+    if not (INIT_G_MIN <= group_count <= INIT_G_MAX):
+        return jsonify({'ok': False, 'error_code': 'VALIDATION',
+                        'message': f'조 수 {INIT_G_MIN}~{INIT_G_MAX} 범위 벗어남'}), 400
+
+    # 중복/빈값 재검증
+    seen = set()
+    for p in ordered:
+        kid = (p.get('knox_id') or '').strip().lower()
+        name = (p.get('name') or '').strip()
+        if not kid or not name:
+            return jsonify({'ok': False, 'error_code': 'VALIDATION', 'message': '빈 knox_id/name 포함'}), 400
+        if kid in seen:
+            return jsonify({'ok': False, 'error_code': 'VALIDATION', 'message': f'중복 knox_id: {kid}'}), 400
+        seen.add(kid)
+
+    # 3) 진행 중 주자 체크
+    force = bool(data.get('force', False))
+    try:
+        in_progress = Runner.query.filter(Runner.started_at.isnot(None)).count()
+    except Exception:
+        # 테이블 없음 (최초 초기화 전) → 진행 중 아님
+        in_progress = 0
+    if in_progress > 0 and not force:
+        return jsonify({
+            'ok': False,
+            'error_code': 'IN_PROGRESS',
+            'message': f'진행 중인 주자 {in_progress}명이 있습니다. 강제 실행 체크 후 재시도하세요.',
+        }), 409
+
+    # 4) 풀 크기 확인
+    regen = bool(data.get('regen_challenge_data', False))
+    pool_size = _current_problem_pool_size()
+    if total_n > pool_size and not regen:
+        return jsonify({
+            'ok': False,
+            'error_code': 'POOL_TOO_SMALL',
+            'message': f'N={total_n}이 풀({pool_size})보다 큽니다. challenge_data.dat 재생성 체크 필요.',
+        }), 400
+
+    # 5) ordered_participants 정규화 (knox_id 소문자, group/order 정수)
+    norm_ordered = []
+    for p in ordered:
+        norm_ordered.append({
+            'knox_id': (p.get('knox_id') or '').strip().lower(),
+            'name':    (p.get('name') or '').strip(),
+            'group':   int(p.get('group', 0)),
+            'order':   int(p.get('order', 0)),
+        })
+
+    # 6) init_database 실행 — 세션/엔진을 먼저 닫아야 Windows에서 DB 파일 삭제 가능
+    db.session.remove()
+    db.engine.dispose()
+
+    from init_db import init_database
+    try:
+        result = init_database(
+            group_count=group_count,
+            group_sizes=group_sizes,
+            ordered_participants=norm_ordered,
+            regen_challenge_data=regen,
+        )
+    except Exception as e:
+        return jsonify({
+            'ok': False,
+            'error_code': 'INTERNAL',
+            'message': f'초기화 실패: {type(e).__name__}: {e}',
+        }), 500
+
+    return jsonify({
+        'ok': True,
+        'first_player_lines': result['first_player_lines'],
+        'summary': {
+            'groups': result['groups'],
+            'runners': result['runners'],
+            'problems': result['runners'],
+        },
+    })
+
+
+@app.route('/admin/init/download/<kind>')
+@admin_required
+def admin_init_download(kind):
+    mapping = {
+        'first-player':   ('firstPlayer.txt',     'text/plain'),
+        'roster':         ('groupRoster.txt',     'text/plain'),
+        'challenge-data': ('challenge_data.dat',  'application/octet-stream'),
+    }
+    if kind not in mapping:
+        abort(404)
+    filename, mime = mapping[kind]
+    path = os.path.join(os.path.dirname(__file__), filename)
+    if not os.path.exists(path):
+        abort(404, description=f'{filename} 없음 (초기화 먼저 실행)')
+    return send_file(path, as_attachment=True, download_name=filename, mimetype=mime)
+
+
+# ============================================================
 # 내부 함수
 # ============================================================
 def _activate_next_runner(current_runner):

--- a/app.py
+++ b/app.py
@@ -20,7 +20,10 @@ import config
 # 설정 파일 (초기화 마법사에서 쓰이는 운영 옵션)
 # ============================================================
 SETTINGS_PATH = os.path.join(os.path.dirname(__file__), 'settings.json')
-DEFAULT_SETTINGS = {'show_individual_ranking': True}
+DEFAULT_SETTINGS = {
+    'show_individual_ranking': True,
+    'challenge_opened': False,   # 참가자에게 공개 여부. 관리자가 명시적으로 열어야 함.
+}
 
 
 def _read_settings() -> dict:
@@ -33,9 +36,29 @@ def _read_settings() -> dict:
 
 
 def _write_settings(data: dict) -> None:
-    merged = {**DEFAULT_SETTINGS, **data}
+    merged = {**DEFAULT_SETTINGS, **_read_settings(), **data}
     with open(SETTINGS_PATH, 'w', encoding='utf-8') as f:
         json.dump(merged, f, ensure_ascii=False, indent=2)
+
+
+def _is_challenge_open() -> bool:
+    """챌린지가 참가자에게 공개되어 있는지. 초기화 전이거나 관리자가 닫은 상태면 False."""
+    try:
+        if Runner.query.count() == 0:
+            return False
+    except Exception:
+        return False
+    return _read_settings().get('challenge_opened', False)
+
+
+def challenge_open_required(f):
+    """챌린지가 열려 있지 않으면 coming_soon 페이지를 렌더."""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not _is_challenge_open():
+            return render_template('coming_soon.html'), 200
+        return f(*args, **kwargs)
+    return decorated
 
 
 def create_app():
@@ -192,6 +215,7 @@ def _is_ajax():
 # 공개 라우트
 # ============================================================
 @app.route('/')
+@challenge_open_required
 def index():
     rankings = get_group_rankings()
     total_completed = sum(r['completed'] for r in rankings)
@@ -203,6 +227,7 @@ def index():
 
 
 @app.route('/login', methods=['POST'])
+@challenge_open_required
 def login():
     knox_id = request.form.get('knox_id', '').strip()
     password = request.form.get('password', '').strip()
@@ -410,6 +435,7 @@ def get_individual_rankings(limit=20):
 
 
 @app.route('/leaderboard')
+@challenge_open_required
 def leaderboard():
     rankings = get_group_rankings()
     settings = _read_settings()
@@ -422,11 +448,13 @@ def leaderboard():
 
 
 @app.route('/guide')
+@challenge_open_required
 def guide():
     return render_template('guide.html')
 
 
 @app.route('/download/challenge_data')
+@challenge_open_required
 def download_challenge_data():
     path = config.CHALLENGE_DATA_PATH
     if not os.path.exists(path):
@@ -435,6 +463,7 @@ def download_challenge_data():
 
 
 @app.route('/api/leaderboard')
+@challenge_open_required
 def api_leaderboard():
     rankings = get_group_rankings()
     data = []
@@ -490,13 +519,17 @@ def admin_dashboard():
     rankings = get_group_rankings()
     total_completed = sum(r['completed'] for r in rankings)
     total_runners = sum(r['total'] for r in rankings)
+    challenge_opened = _is_challenge_open()
+    initialized = Runner.query.count() > 0
 
     return render_template('admin_dashboard.html',
                            groups=groups,
                            grouped=grouped,
                            rankings=rankings,
                            total_completed=total_completed,
-                           total_runners=total_runners)
+                           total_runners=total_runners,
+                           challenge_opened=challenge_opened,
+                           initialized=initialized)
 
 
 @app.route('/admin/skip/<int:runner_id>', methods=['POST'])
@@ -687,7 +720,27 @@ def admin_api_status():
 @app.route('/admin/logout')
 def admin_logout():
     session.pop('is_admin', None)
-    return redirect(url_for('index'))
+    return redirect(url_for('admin_login'))
+
+
+@app.route('/admin/toggle-open', methods=['POST'])
+@admin_required
+def admin_toggle_open():
+    """챌린지 공개/비공개 토글. 초기화 전(Runner 0)이면 열 수 없음."""
+    if Runner.query.count() == 0:
+        if _is_ajax():
+            return jsonify({'ok': False, 'message': '초기화가 완료되지 않았습니다.'}), 400
+        flash('초기화가 완료되지 않았습니다.', 'warning')
+        return redirect(url_for('admin_dashboard'))
+
+    settings = _read_settings()
+    new_state = not settings.get('challenge_opened', False)
+    _write_settings({'challenge_opened': new_state})
+
+    if _is_ajax():
+        return jsonify({'ok': True, 'opened': new_state})
+    flash('챌린지를 공개했습니다.' if new_state else '챌린지를 비공개로 전환했습니다.', 'success')
+    return redirect(url_for('admin_dashboard'))
 
 
 # ============================================================
@@ -960,8 +1013,12 @@ def admin_init_commit():
         }), 500
 
     # 7) 운영 옵션 저장 (DB 초기화와 독립)
+    # 초기화 직후에는 항상 비공개 상태로 리셋 — 관리자가 명시적으로 "공개"해야 참가자 접근 가능
     try:
-        _write_settings({'show_individual_ranking': show_individual})
+        _write_settings({
+            'show_individual_ranking': show_individual,
+            'challenge_opened': False,
+        })
     except OSError:
         pass  # 파일 쓰기 실패해도 초기화 자체는 성공으로 간주
 

--- a/app.py
+++ b/app.py
@@ -948,6 +948,7 @@ def admin_init_download(kind):
         'first-player':   ('firstPlayer.txt',     'text/plain'),
         'roster':         ('groupRoster.txt',     'text/plain'),
         'challenge-data': ('challenge_data.dat',  'application/octet-stream'),
+        'relay-db':       ('relay.db',            'application/x-sqlite3'),
     }
     if kind not in mapping:
         abort(404)
@@ -955,6 +956,38 @@ def admin_init_download(kind):
     path = os.path.join(os.path.dirname(__file__), filename)
     if not os.path.exists(path):
         abort(404, description=f'{filename} 없음 (초기화 먼저 실행)')
+
+    # SQLite DB는 사용 중일 수 있으므로 backup API로 일관된 스냅샷을 만들어 전송
+    if kind == 'relay-db':
+        import sqlite3
+        import tempfile
+        from flask import after_this_request
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix='.db')
+        os.close(tmp_fd)
+        try:
+            src = sqlite3.connect(path)
+            dst = sqlite3.connect(tmp_path)
+            with dst:
+                src.backup(dst)
+            dst.close()
+            src.close()
+        except Exception:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+
+        @after_this_request
+        def _cleanup(response):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            return response
+
+        return send_file(tmp_path, as_attachment=True, download_name=filename, mimetype=mime)
+
     return send_file(path, as_attachment=True, download_name=filename, mimetype=mime)
 
 

--- a/generate_challenge.py
+++ b/generate_challenge.py
@@ -22,8 +22,12 @@ from openpyxl.utils import get_column_letter
 # 설정
 # ============================================================
 SEED = 2026
-NUM_PARTICIPANTS = 130
-PROBLEMS_PER_TYPE = 26  # 5 types x 26 = 130
+DEFAULT_TOTAL_PROBLEMS = 130
+NUM_PROBLEM_TYPES = 5  # F, G, H, I, J
+
+# 하위호환: 기존 코드가 이 상수를 참조할 수 있으므로 기본값 유지
+NUM_PARTICIPANTS = DEFAULT_TOTAL_PROBLEMS
+PROBLEMS_PER_TYPE = math.ceil(DEFAULT_TOTAL_PROBLEMS / NUM_PROBLEM_TYPES)
 
 random.seed(SEED)
 
@@ -779,9 +783,9 @@ def generate_type_e_problems(registry_entries, n=PROBLEMS_PER_TYPE):
 # ============================================================
 
 STEP1_MIN = 3
-STEP1_MAX = 150
+STEP1_MAX = 400
 STEP2_MIN = 5
-STEP2_MAX = 100
+STEP2_MAX = 300
 
 
 def _in_range(size, lo, hi):
@@ -912,7 +916,6 @@ def generate_type_h_problems(registry_entries, json_records, n=PROBLEMS_PER_TYPE
 def generate_type_i_problems(log_entries, json_records, n=PROBLEMS_PER_TYPE):
     """Type I — 2-hop: LOG(module+level) → JSON(emp+status) → 레코드 수."""
     problems = []
-    used_answers = set()
 
     combos = [(m, l, s) for m in MODULES for l in LOG_LEVELS for s in STATUSES]
     random.shuffle(combos)
@@ -929,9 +932,6 @@ def generate_type_i_problems(log_entries, json_records, n=PROBLEMS_PER_TYPE):
         if not _in_range(len(records), STEP2_MIN, STEP2_MAX):
             continue
         answer = f"{len(records)}"
-        if answer in used_answers:
-            continue
-        used_answers.add(answer)
 
         text = (f"challenge_data.dat 파일에서 2단계 분석을 수행하세요:\n"
                 f"[1단계] LOG_SECTION 섹션들에서 module=\"{module}\", level={level} 인 로그의 employee_id를 수집하세요 (중복 제거).\n"
@@ -950,7 +950,6 @@ def generate_type_i_problems(log_entries, json_records, n=PROBLEMS_PER_TYPE):
 def generate_type_j_problems(log_entries, registry_entries, n=PROBLEMS_PER_TYPE):
     """Type J — 2-hop: LOG(module+level) → REGISTRY(ref+tag) → 항목 수."""
     problems = []
-    used_answers = set()
 
     combos = [(m, l, t) for m in MODULES for l in LOG_LEVELS for t in TAGS]
     random.shuffle(combos)
@@ -967,9 +966,6 @@ def generate_type_j_problems(log_entries, registry_entries, n=PROBLEMS_PER_TYPE)
         if not _in_range(len(entries), STEP2_MIN, STEP2_MAX):
             continue
         answer = f"{len(entries)}"
-        if answer in used_answers:
-            continue
-        used_answers.add(answer)
 
         text = (f"challenge_data.dat 파일에서 2단계 분석을 수행하세요:\n"
                 f"[1단계] LOG_SECTION 섹션들에서 module=\"{module}\", level={level} 인 로그의 employee_id를 수집하세요 (중복 제거).\n"
@@ -983,6 +979,94 @@ def generate_type_j_problems(log_entries, registry_entries, n=PROBLEMS_PER_TYPE)
                     "step1": len(emp_ids), "step2": len(entries)}
         ))
     return problems
+
+
+# ============================================================
+# 스케일링 도우미
+# ============================================================
+def _scaled_data_sizes(total_problems: int) -> dict:
+    """total_problems에 비례한 제너레이터 데이터 크기 반환."""
+    return {
+        "n_employees":         max(800,  total_problems * 4),
+        "n_log_sections":      max(60,   math.ceil(total_problems / 3)),
+        "log_lines_per_section": 80,
+        "n_registry_sections": max(30,   math.ceil(total_problems / 6)),
+        "registry_entries_per_section": 100,
+    }
+
+
+def _build_pools(total_problems: int):
+    """유형별 풀을 생성해 (pools, data_bundle) 반환. 내부에서 seed 재설정."""
+    random.seed(SEED)
+    sizes = _scaled_data_sizes(total_problems)
+    per_type = math.ceil(total_problems / NUM_PROBLEM_TYPES)
+
+    employees = generate_employees(sizes["n_employees"])
+    log_sections, log_entries = generate_log_sections(
+        employees,
+        n_sections=sizes["n_log_sections"],
+        lines_per_section=sizes["log_lines_per_section"],
+    )
+    json_sections, json_records = generate_json_blocks(employees)
+    csv_sections, csv_rows = generate_csv_tables()
+    code_sections, code_data = generate_code_blocks()
+    registry_sections, registry_entries = generate_registry_sections(
+        n_sections=sizes["n_registry_sections"],
+        entries_per_section=sizes["registry_entries_per_section"],
+        emp_count=len(employees),
+    )
+    prose_sections = generate_prose_blocks()
+    meta_sections = generate_metadata_dumps()
+
+    pools = [
+        generate_type_f_problems(json_records, log_entries, n=per_type),
+        generate_type_g_problems(json_records, registry_entries, n=per_type),
+        generate_type_h_problems(registry_entries, json_records, n=per_type),
+        generate_type_i_problems(log_entries, json_records, n=per_type),
+        generate_type_j_problems(log_entries, registry_entries, n=per_type),
+    ]
+
+    bundle = {
+        "all_sections": (log_sections + json_sections + csv_sections +
+                         code_sections + registry_sections +
+                         prose_sections + meta_sections),
+        "log_sections": log_sections,
+        "log_entries": log_entries,
+        "json_sections": json_sections,
+        "json_records": json_records,
+        "csv_sections": csv_sections,
+        "csv_rows": csv_rows,
+        "code_sections": code_sections,
+        "code_data": code_data,
+        "registry_sections": registry_sections,
+        "registry_entries": registry_entries,
+        "prose_sections": prose_sections,
+        "meta_sections": meta_sections,
+    }
+    return pools, bundle
+
+
+def _assign_problems_from_pools(pools, total_problems):
+    """5개 풀을 순환하며 total_problems개를 배정. 부족하면 다른 풀에서 보충."""
+    pool_indices = [0] * NUM_PROBLEM_TYPES
+    assigned = []
+    for i in range(total_problems):
+        type_idx = i % NUM_PROBLEM_TYPES
+        pool = pools[type_idx]
+        if pool_indices[type_idx] < len(pool):
+            p = pool[pool_indices[type_idx]]
+            p.pid = i + 1
+            assigned.append(p)
+            pool_indices[type_idx] += 1
+        else:
+            for alt in range(NUM_PROBLEM_TYPES):
+                if pool_indices[alt] < len(pools[alt]):
+                    p = pools[alt][pool_indices[alt]]
+                    p.pid = i + 1
+                    assigned.append(p)
+                    pool_indices[alt] += 1
+                    break
+    return assigned
 
 
 # ============================================================
@@ -1088,18 +1172,19 @@ def create_excel(all_problems, filename="challenge_admin.xlsx"):
 
     # --- Sheet 3: 진행 가이드 ---
     ws3 = wb.create_sheet("진행 가이드")
+    total_participants = len(all_problems)
     guide_content = [
         ["코딩 에이전트 릴레이 설치 챌린지 - 진행 가이드", ""],
         ["", ""],
         ["[개요]", ""],
         ["목적", "팀원 전원이 코딩 에이전트(Roo Code 또는 Open Code)를 설치하고 사용할 수 있는지 확인"],
-        ["인원", "약 130명 (6~7명 x 약 19조)"],
+        ["인원", f"{total_participants}명 (조별 배정 init_db.py에서 확정)"],
         ["방식", "릴레이 - 첫 번째 사람이 설치 후 다음 사람에게 설치 방법을 전수"],
         ["", ""],
         ["[사전 준비]", ""],
         ["1", "generate_challenge.py를 실행하여 challenge_data.dat와 이 엑셀 파일 생성"],
         ["2", "challenge_data.dat를 참가자 전원에게 배포 (공유 드라이브, Slack 등)"],
-        ["3", "각 참가자에게 참가자번호(1~130) 할당"],
+        ["3", f"각 참가자에게 참가자번호(1~{total_participants}) 할당"],
         ["4", "'문제카드 배포용' 시트에서 각자의 문제를 확인하도록 안내"],
         ["", ""],
         ["[Roo Code 설치 방법]", ""],
@@ -1156,14 +1241,15 @@ def create_excel(all_problems, filename="challenge_admin.xlsx"):
         cell.alignment = Alignment(horizontal="center")
         cell.border = thin_border
 
-    total_groups = math.ceil(NUM_PARTICIPANTS / 7)
+    total_participants = len(all_problems)
+    total_groups = math.ceil(total_participants / 7)
     for g in range(1, total_groups + 1):
         row = g + 1
         start_row = (g - 1) * 7 + 2
-        end_row = min(g * 7 + 1, NUM_PARTICIPANTS + 1)
+        end_row = min(g * 7 + 1, total_participants + 1)
 
         ws4.cell(row=row, column=1, value=g).border = thin_border
-        ws4.cell(row=row, column=2, value=min(7, NUM_PARTICIPANTS - (g - 1) * 7)).border = thin_border
+        ws4.cell(row=row, column=2, value=min(7, total_participants - (g - 1) * 7)).border = thin_border
         ws4.cell(row=row, column=3,
                  value=f'=COUNTIF(마스터 답안지!G{start_row}:G{end_row},"PASS")').border = thin_border
         ws4.cell(row=row, column=4,
@@ -1199,21 +1285,35 @@ def create_excel(all_problems, filename="challenge_admin.xlsx"):
 # ============================================================
 # 메인
 # ============================================================
-def main():
+def main(total_problems: int = DEFAULT_TOTAL_PROBLEMS,
+         output_path: str = "challenge_data.dat",
+         excel_path: str = "challenge_admin.xlsx"):
     print("=" * 60)
-    print("코딩 에이전트 릴레이 설치 챌린지 - 문제 생성기")
+    print(f"코딩 에이전트 릴레이 설치 챌린지 - 문제 생성기 (N={total_problems})")
     print("=" * 60)
 
-    # 1. 데이터 생성 (2차: 데이터 볼륨 증량)
-    print("\n[1/6] 직원 풀 생성...")
-    employees = generate_employees(800)
+    sizes = _scaled_data_sizes(total_problems)
+    per_type = math.ceil(total_problems / NUM_PROBLEM_TYPES)
+
+    # 1. 데이터 생성
+    random.seed(SEED)
+    print(f"\n[1/6] 직원 풀 생성 (n={sizes['n_employees']})...")
+    employees = generate_employees(sizes["n_employees"])
 
     print("[2/6] 섹션 생성...")
-    log_sections, log_entries = generate_log_sections(employees, n_sections=60, lines_per_section=80)
+    log_sections, log_entries = generate_log_sections(
+        employees,
+        n_sections=sizes["n_log_sections"],
+        lines_per_section=sizes["log_lines_per_section"],
+    )
     json_sections, json_records = generate_json_blocks(employees)
     csv_sections, csv_rows = generate_csv_tables()
     code_sections, code_data = generate_code_blocks()
-    registry_sections, registry_entries = generate_registry_sections(n_sections=30, entries_per_section=100, emp_count=len(employees))
+    registry_sections, registry_entries = generate_registry_sections(
+        n_sections=sizes["n_registry_sections"],
+        entries_per_section=sizes["registry_entries_per_section"],
+        emp_count=len(employees),
+    )
     prose_sections = generate_prose_blocks()
     meta_sections = generate_metadata_dumps()
 
@@ -1230,21 +1330,21 @@ def main():
     print(f"  - 메타데이터: {len(meta_sections)} dumps")
 
     # 2. 파일 조립
-    print("\n[3/6] challenge_data.dat 생성...")
+    print(f"\n[3/6] {output_path} 생성...")
     file_content = assemble_challenge_file(all_sections)
-    with open("challenge_data.dat", "w", encoding="utf-8") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(file_content)
     line_count = file_content.count("\n") + 1
     file_size = len(file_content.encode("utf-8"))
     print(f"  -> {line_count:,} 줄, {file_size:,} bytes ({file_size / 1024:.1f} KB)")
 
-    # 3. 문제 생성 (2차 — 전부 2-hop 균일 난이도)
-    print("\n[4/6] 130개 고유 2-hop 문제 생성...")
-    problems_f = generate_type_f_problems(json_records, log_entries)
-    problems_g = generate_type_g_problems(json_records, registry_entries)
-    problems_h = generate_type_h_problems(registry_entries, json_records)
-    problems_i = generate_type_i_problems(log_entries, json_records)
-    problems_j = generate_type_j_problems(log_entries, registry_entries)
+    # 3. 문제 생성 (모든 유형 2-hop, 유형별 per_type개씩 요청)
+    print(f"\n[4/6] {total_problems}개 2-hop 문제 생성 (유형별 {per_type}개 시도)...")
+    problems_f = generate_type_f_problems(json_records, log_entries, n=per_type)
+    problems_g = generate_type_g_problems(json_records, registry_entries, n=per_type)
+    problems_h = generate_type_h_problems(registry_entries, json_records, n=per_type)
+    problems_i = generate_type_i_problems(log_entries, json_records, n=per_type)
+    problems_j = generate_type_j_problems(log_entries, registry_entries, n=per_type)
 
     print(f"  Type F (JSON→LOG 합계): {len(problems_f)}개")
     print(f"  Type G (JSON→REG 합계): {len(problems_g)}개")
@@ -1252,28 +1352,15 @@ def main():
     print(f"  Type I (LOG→JSON 카운트): {len(problems_i)}개")
     print(f"  Type J (LOG→REG 카운트): {len(problems_j)}개")
 
-    # 문제 배정: 타입을 순환하며 배정 (조 내에서 다양한 유형이 나오도록)
     all_pools = [problems_f, problems_g, problems_h, problems_i, problems_j]
-    pool_indices = [0, 0, 0, 0, 0]
-    all_problems = []
+    total_generated = sum(len(p) for p in all_pools)
+    if total_generated < total_problems:
+        raise RuntimeError(
+            f"문제 생성 부족: 요청 {total_problems}개, 생성 {total_generated}개. "
+            "섹션 풀 크기를 키우거나 난이도 제약(STEP1/STEP2 MIN/MAX)을 완화하세요."
+        )
 
-    for i in range(NUM_PARTICIPANTS):
-        type_idx = i % 5
-        pool = all_pools[type_idx]
-        if pool_indices[type_idx] < len(pool):
-            p = pool[pool_indices[type_idx]]
-            p.pid = i + 1
-            all_problems.append(p)
-            pool_indices[type_idx] += 1
-        else:
-            # 풀이 부족하면 다른 타입에서 가져옴
-            for alt in range(5):
-                if pool_indices[alt] < len(all_pools[alt]):
-                    p = all_pools[alt][pool_indices[alt]]
-                    p.pid = i + 1
-                    all_problems.append(p)
-                    pool_indices[alt] += 1
-                    break
+    all_problems = _assign_problems_from_pools(all_pools, total_problems)
 
     # 답 중복 검사
     answers = [p.answer for p in all_problems]
@@ -1286,63 +1373,35 @@ def main():
 
     # 4. 엑셀 생성
     print("\n[5/6] 엑셀 파일 생성...")
-    create_excel(all_problems, "challenge_admin.xlsx")
+    create_excel(all_problems, excel_path)
 
     # 5. 완료 요약
     print("\n[6/6] 완료!")
     print("=" * 60)
     print("생성된 파일:")
-    print(f"  1. challenge_data.dat  ({line_count:,} 줄, {file_size / 1024:.1f} KB)")
-    print(f"  2. challenge_admin.xlsx (4개 시트)")
+    print(f"  1. {output_path}  ({line_count:,} 줄, {file_size / 1024:.1f} KB)")
+    print(f"  2. {excel_path} (4개 시트)")
     print("=" * 60)
-    print("\n사용 방법:")
-    print("  1. challenge_data.dat를 참가자에게 배포")
-    print("  2. challenge_admin.xlsx의 '문제카드 배포용' 시트에서 각자 문제 확인")
-    print("  3. 참가자가 코딩 에이전트로 문제를 풀고 답 제출")
-    print("  4. '마스터 답안지' 시트의 F열에 제출답안 입력 → G열에서 자동 판정")
 
 
-def get_all_problems():
-    """외부에서 호출하여 130개 문제 목록을 반환하는 함수."""
-    random.seed(SEED)
-    employees = generate_employees(800)
-    log_sections, log_entries = generate_log_sections(employees, n_sections=60, lines_per_section=80)
-    json_sections, json_records = generate_json_blocks(employees)
-    csv_sections, csv_rows = generate_csv_tables()
-    code_sections, code_data = generate_code_blocks()
-    registry_sections, registry_entries = generate_registry_sections(n_sections=30, entries_per_section=100, emp_count=len(employees))
-    _ = generate_prose_blocks()
-    _ = generate_metadata_dumps()
-
-    problems_f = generate_type_f_problems(json_records, log_entries)
-    problems_g = generate_type_g_problems(json_records, registry_entries)
-    problems_h = generate_type_h_problems(registry_entries, json_records)
-    problems_i = generate_type_i_problems(log_entries, json_records)
-    problems_j = generate_type_j_problems(log_entries, registry_entries)
-
-    all_pools = [problems_f, problems_g, problems_h, problems_i, problems_j]
-    pool_indices = [0, 0, 0, 0, 0]
-    all_problems = []
-
-    for i in range(NUM_PARTICIPANTS):
-        type_idx = i % 5
-        pool = all_pools[type_idx]
-        if pool_indices[type_idx] < len(pool):
-            p = pool[pool_indices[type_idx]]
-            p.pid = i + 1
-            all_problems.append(p)
-            pool_indices[type_idx] += 1
-        else:
-            for alt in range(5):
-                if pool_indices[alt] < len(all_pools[alt]):
-                    p = all_pools[alt][pool_indices[alt]]
-                    p.pid = i + 1
-                    all_problems.append(p)
-                    pool_indices[alt] += 1
-                    break
-
-    return all_problems
+def get_all_problems(total_problems: int = DEFAULT_TOTAL_PROBLEMS):
+    """외부에서 호출하여 total_problems개 문제 목록을 반환."""
+    pools, _bundle = _build_pools(total_problems)
+    total_generated = sum(len(p) for p in pools)
+    if total_generated < total_problems:
+        raise RuntimeError(
+            f"문제 생성 부족: 요청 {total_problems}개, 생성 {total_generated}개."
+        )
+    return _assign_problems_from_pools(pools, total_problems)
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    n = DEFAULT_TOTAL_PROBLEMS
+    if len(sys.argv) > 1:
+        try:
+            n = int(sys.argv[1])
+        except ValueError:
+            print(f"사용법: python generate_challenge.py [total_problems]")
+            sys.exit(1)
+    main(total_problems=n)

--- a/init_db.py
+++ b/init_db.py
@@ -119,8 +119,8 @@ def init_database(
     }
     """
     sys.path.insert(0, BASE_DIR)
-    from app import create_app
     from models import db, Group, Runner
+    from flask import current_app, has_app_context
 
     # ordered_participants가 주어지면 N도 거기서 도출
     if ordered_participants is not None:
@@ -149,12 +149,23 @@ def init_database(
             excel_path=os.path.join(BASE_DIR, "challenge_admin.xlsx"),
         )
 
-    app = create_app()
+    # Flask 앱 컨텍스트가 이미 있으면 재사용(웹 경로), 없으면 새로 생성(CLI 경로)
+    from contextlib import nullcontext
+    if has_app_context():
+        app = current_app._get_current_object()
+        ctx = nullcontext()
+    else:
+        from app import create_app
+        app = create_app()
+        ctx = app.app_context()
+
     first_player_lines: list[str] = []
     group_roster: dict[int, list] = {}
 
-    with app.app_context():
-        # 기존 DB 삭제 후 재생성
+    with ctx:
+        # 기존 DB 삭제 후 재생성 — Windows에서 파일 잠금 해제
+        db.session.remove()
+        db.engine.dispose()
         db_path = app.config['SQLALCHEMY_DATABASE_URI'].replace('sqlite:///', '')
         if os.path.exists(db_path):
             os.remove(db_path)

--- a/init_db.py
+++ b/init_db.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """
 데이터베이스 초기화 스크립트.
-130명의 참가자, 10개 조, 130개 고유 문제를 DB에 세팅합니다.
+참가자/조/문제를 DB에 세팅합니다. CLI 기본값은 130명 10조.
+
+웹(/admin/init)에서 호출 시에는 init_database()에 group_count, group_sizes,
+ordered_participants 를 넘겨 순서를 확정한 상태로 초기화합니다.
 """
 
 import os
@@ -11,14 +14,14 @@ import random
 import secrets
 import string
 
-from generate_challenge import get_all_problems
+from generate_challenge import get_all_problems, main as generate_main
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 CSV_PATH = os.path.join(BASE_DIR, "Generative-AI팀-AI샌터_챌린지_대상.csv")
 
-NUM_GROUPS = 10
-PARTICIPANTS_PER_GROUP = 13
-TOTAL_PARTICIPANTS = NUM_GROUPS * PARTICIPANTS_PER_GROUP  # 130
+DEFAULT_NUM_GROUPS = 10
+DEFAULT_PARTICIPANTS_PER_GROUP = 13
+DEFAULT_TOTAL = DEFAULT_NUM_GROUPS * DEFAULT_PARTICIPANTS_PER_GROUP  # 130
 
 
 def generate_password(length=8):
@@ -26,12 +29,21 @@ def generate_password(length=8):
     return ''.join(secrets.choice(alphabet) for _ in range(length))
 
 
+def compute_group_sizes(total: int, group_count: int) -> list[int]:
+    """나머지를 앞 조부터 +1명 분배하여 조별 정원 리스트 반환."""
+    if group_count <= 0 or total < group_count:
+        raise ValueError(f"invalid total={total} group_count={group_count}")
+    base = total // group_count
+    remainder = total % group_count
+    return [base + 1 if g < remainder else base for g in range(group_count)]
+
+
 def load_participants_from_csv(path):
     """CSV에서 참가자 목록을 읽어옵니다. 컬럼: knox_id, name, group(선택)
-    group 컬럼이 있고 값이 1~10이면 해당 조의 첫 번째 주자로 고정됩니다.
+    group 컬럼이 있고 값이 1 이상이면 해당 조의 첫 번째 주자로 고정됩니다.
     반환: (first_players dict {group_id: member}, 일반참가자 list)
     """
-    first_players = {}  # {group_id: member}
+    first_players = {}
     participants = []
     with open(path, 'r', encoding='utf-8-sig') as f:
         reader = csv.DictReader(f)
@@ -41,15 +53,14 @@ def load_participants_from_csv(path):
                 'name': row.get('name', row.get('이름', '')).strip(),
             }
             group_val = row.get('group', '').strip()
-            if group_val.isdigit() and 1 <= int(group_val) <= NUM_GROUPS:
+            if group_val.isdigit() and int(group_val) >= 1:
                 first_players[int(group_val)] = member
             else:
                 participants.append(member)
     return first_players, participants
 
 
-def generate_test_participants(n=TOTAL_PARTICIPANTS):
-    """테스트용 참가자 데이터 생성."""
+def generate_test_participants(n=DEFAULT_TOTAL):
     participants = []
     for i in range(1, n + 1):
         participants.append({
@@ -59,13 +70,88 @@ def generate_test_participants(n=TOTAL_PARTICIPANTS):
     return participants
 
 
-def init_database():
-    # Flask 앱 컨텍스트에서 DB 생성
+def _write_first_player_file(first_player_lines, path):
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write("=" * 60 + "\n")
+        f.write("코딩 에이전트 릴레이 챌린지 - 첫 번째 주자 비밀번호\n")
+        f.write("=" * 60 + "\n\n")
+        for line in first_player_lines:
+            f.write(line + "\n")
+        f.write("\n" + "=" * 60 + "\n")
+        f.write("이 비밀번호를 각 조의 첫 번째 주자에게 전달하세요.\n")
+
+
+def _write_roster_file(group_roster, path):
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write("=" * 80 + "\n")
+        f.write("코딩 에이전트 릴레이 챌린지 - 조별 주자 순서 (비상용)\n")
+        f.write("=" * 80 + "\n")
+        f.write("※ 시스템 장애 시 이 파일을 보고 수동으로 진행할 수 있습니다.\n")
+        f.write("※ 정답이 포함되어 있으므로 참가자에게 공유하지 마세요.\n")
+        f.write("=" * 80 + "\n\n")
+        for g_id, members in group_roster.items():
+            f.write(f"[ 조 {g_id} ]\n")
+            f.write(f"{'순서':>4}  {'이름':<20}  {'Knox-ID':<20}  {'정답'}\n")
+            f.write("-" * 70 + "\n")
+            for m in members:
+                f.write(f"{m['order']:>4}  {m['name']:<20}  {m['knox_id']:<20}  {m['answer']}\n")
+            f.write("\n")
+        f.write("=" * 80 + "\n")
+
+
+def init_database(
+    group_count: int = DEFAULT_NUM_GROUPS,
+    group_sizes: list[int] | None = None,
+    ordered_participants: list[dict] | None = None,
+    regen_challenge_data: bool = False,
+) -> dict:
+    """
+    DB를 삭제 후 재생성하고 참가자·조·문제를 배정한다.
+
+    group_sizes=None 이면 group_count에 따라 균등 분배(+나머지는 앞 조부터).
+    ordered_participants=None 이면 기존 CSV + random.shuffle 로직으로 폴백 (CLI 하위호환).
+
+    반환: {
+        'first_player_lines': [...],
+        'roster_path': str,
+        'runners': int,
+        'groups': int,
+    }
+    """
     sys.path.insert(0, BASE_DIR)
     from app import create_app
     from models import db, Group, Runner
 
+    # ordered_participants가 주어지면 N도 거기서 도출
+    if ordered_participants is not None:
+        total = len(ordered_participants)
+    else:
+        total = sum(group_sizes) if group_sizes else DEFAULT_TOTAL
+
+    if group_sizes is None:
+        group_sizes = compute_group_sizes(total, group_count)
+    else:
+        if len(group_sizes) != group_count:
+            raise ValueError(
+                f"group_sizes 길이({len(group_sizes)}) != group_count({group_count})"
+            )
+        if sum(group_sizes) != total:
+            raise ValueError(
+                f"group_sizes 합({sum(group_sizes)}) != total({total})"
+            )
+
+    # 문제 풀 재생성 (필요 시)
+    if regen_challenge_data:
+        print(f"challenge_data.dat 재생성 (N={total})...")
+        generate_main(
+            total_problems=total,
+            output_path=os.path.join(BASE_DIR, "challenge_data.dat"),
+            excel_path=os.path.join(BASE_DIR, "challenge_admin.xlsx"),
+        )
+
     app = create_app()
+    first_player_lines: list[str] = []
+    group_roster: dict[int, list] = {}
 
     with app.app_context():
         # 기존 DB 삭제 후 재생성
@@ -77,74 +163,93 @@ def init_database():
         db.create_all()
         print("DB 테이블 생성 완료")
 
-        # 1. 참가자 로드
-        if os.path.exists(CSV_PATH):
-            first_players, participants = load_participants_from_csv(CSV_PATH)
-            print(f"CSV에서 고정 첫번째 주자 {len(first_players)}명, 일반 참가자 {len(participants)}명 로드")
-        else:
-            first_players = {}
-            participants = generate_test_participants()
-            print(f"테스트 참가자 {len(participants)}명 생성")
+        try:
+            # 1. 문제 로드 (total개)
+            print(f"{total}개 문제 로드 중...")
+            problems = get_all_problems(total_problems=total)
+            if len(problems) < total:
+                raise RuntimeError(
+                    f"문제 부족: 요청 {total}개, 생성 {len(problems)}개. "
+                    "regen_challenge_data=True 로 재생성하세요."
+                )
+            print(f"  {len(problems)}개 문제 준비 완료")
 
-        # 고정 첫번째 주자가 없는 조는 일반 참가자에서 채워야 하므로 총 필요 인원 계산
-        remaining_needed = TOTAL_PARTICIPANTS - len(first_players)
-        if len(participants) < remaining_needed:
-            print(f"경고: 일반 참가자 {len(participants)}명 < 필요 {remaining_needed}명")
-            for i in range(len(participants) + 1, remaining_needed + 1):
-                participants.append({
-                    'knox_id': f'extra{i:03d}',
-                    'name': f'추가참가자{i:03d}',
-                })
-
-        participants = participants[:remaining_needed]
-
-        # 2. 문제 로드
-        print("130개 문제 생성 중...")
-        problems = get_all_problems()
-        print(f"  {len(problems)}개 문제 준비 완료")
-
-        # 3. 일반 참가자만 랜덤으로 섞기
-        random.seed(2026)
-        random.shuffle(participants)
-
-        # 4. 조 생성 및 참가자 배정
-        first_player_lines = []
-        group_roster = {}  # 조별 주자 순서 기록
-        regular_idx = 0  # 일반 참가자 인덱스
-
-        for g in range(NUM_GROUPS):
-            group = Group(id=g + 1, name=f"조 {g + 1}")
-            db.session.add(group)
-            group_roster[g + 1] = []
-
-            # 첫 번째 주자: 고정 지정 or 일반 참가자에서 배정
-            if (g + 1) in first_players:
-                fixed_first = first_players[g + 1]
-                group_members = [fixed_first] + participants[regular_idx:regular_idx + PARTICIPANTS_PER_GROUP - 1]
-                regular_idx += PARTICIPANTS_PER_GROUP - 1
+            # 2. 참가자 순서 확정
+            if ordered_participants is not None:
+                # 웹 경로: 이미 확정된 순서 그대로 사용
+                final_order = ordered_participants
             else:
-                group_members = participants[regular_idx:regular_idx + PARTICIPANTS_PER_GROUP]
-                regular_idx += PARTICIPANTS_PER_GROUP
+                # CLI 폴백: CSV + random.shuffle
+                if os.path.exists(CSV_PATH):
+                    first_players, participants = load_participants_from_csv(CSV_PATH)
+                    print(f"CSV에서 고정 첫번째 주자 {len(first_players)}명, 일반 참가자 {len(participants)}명 로드")
+                else:
+                    first_players = {}
+                    participants = generate_test_participants(total)
+                    print(f"테스트 참가자 {len(participants)}명 생성")
 
-            for order, member in enumerate(group_members, 1):
-                problem_idx = g * PARTICIPANTS_PER_GROUP + (order - 1)
+                remaining_needed = total - len(first_players)
+                if len(participants) < remaining_needed:
+                    print(f"경고: 일반 참가자 {len(participants)}명 < 필요 {remaining_needed}명")
+                    for i in range(len(participants) + 1, remaining_needed + 1):
+                        participants.append({
+                            'knox_id': f'extra{i:03d}',
+                            'name': f'추가참가자{i:03d}',
+                        })
+                participants = participants[:remaining_needed]
+
+                random.seed(2026)
+                random.shuffle(participants)
+
+                # 조별로 정원만큼 배정, 고정 1번 주자는 앞에
+                final_order = []
+                regular_idx = 0
+                for g in range(group_count):
+                    size = group_sizes[g]
+                    if (g + 1) in first_players:
+                        fixed = first_players[g + 1]
+                        members = [fixed] + participants[regular_idx:regular_idx + size - 1]
+                        regular_idx += size - 1
+                    else:
+                        members = participants[regular_idx:regular_idx + size]
+                        regular_idx += size
+                    for order, m in enumerate(members, 1):
+                        final_order.append({
+                            'knox_id': m['knox_id'],
+                            'name': m['name'],
+                            'group': g + 1,
+                            'order': order,
+                        })
+
+            # 3. 조 생성 및 Runner 레코드 삽입
+            for g in range(group_count):
+                group = Group(id=g + 1, name=f"조 {g + 1}")
+                db.session.add(group)
+                group_roster[g + 1] = []
+
+            # 조별 시작 인덱스 (문제 배정용)
+            group_offsets = [sum(group_sizes[:g]) for g in range(group_count)]
+
+            for entry in final_order:
+                g_id = entry['group']
+                order = entry['order']
+                problem_idx = group_offsets[g_id - 1] + (order - 1)
                 problem = problems[problem_idx]
 
-                # 첫 번째 주자는 초기 비밀번호 생성, status='active'
                 if order == 1:
                     password = generate_password()
                     status = 'active'
                     first_player_lines.append(
-                        f"조 {g + 1} | {member['name']} ({member['knox_id']}) | 비밀번호: {password}"
+                        f"조 {g_id} | {entry['name']} ({entry['knox_id']}) | 비밀번호: {password}"
                     )
                 else:
-                    password = ''  # 이전 주자가 완료해야 생성됨
+                    password = ''
                     status = 'waiting'
 
                 runner = Runner(
-                    knox_id=member['knox_id'],
-                    name=member['name'],
-                    group_id=g + 1,
+                    knox_id=entry['knox_id'],
+                    name=entry['name'],
+                    group_id=g_id,
                     run_order=order,
                     password=password,
                     problem_text=problem.text,
@@ -154,56 +259,44 @@ def init_database():
                 )
                 db.session.add(runner)
 
-                group_roster[g + 1].append({
+                group_roster[g_id].append({
                     'order': order,
-                    'name': member['name'],
-                    'knox_id': member['knox_id'],
+                    'name': entry['name'],
+                    'knox_id': entry['knox_id'],
                     'answer': problem.answer,
                 })
 
-        db.session.commit()
-        print(f"\n{NUM_GROUPS}개 조, {TOTAL_PARTICIPANTS}명 배정 완료")
+            db.session.commit()
+            print(f"\n{group_count}개 조, {total}명 배정 완료")
 
-        # 5. firstPlayer.txt 생성
+        except Exception:
+            db.session.rollback()
+            raise
+
+        # 4. 파일 생성
         first_player_path = os.path.join(BASE_DIR, 'firstPlayer.txt')
-        with open(first_player_path, 'w', encoding='utf-8') as f:
-            f.write("=" * 60 + "\n")
-            f.write("코딩 에이전트 릴레이 챌린지 - 첫 번째 주자 비밀번호\n")
-            f.write("=" * 60 + "\n\n")
-            for line in first_player_lines:
-                f.write(line + "\n")
-            f.write("\n" + "=" * 60 + "\n")
-            f.write("이 비밀번호를 각 조의 첫 번째 주자에게 전달하세요.\n")
-        print(f"\nfirstPlayer.txt 생성 완료")
+        _write_first_player_file(first_player_lines, first_player_path)
+        print(f"firstPlayer.txt 생성 완료")
 
-        # 6. groupRoster.txt 생성 (조별 전체 주자 순서 + 정답)
         roster_path = os.path.join(BASE_DIR, 'groupRoster.txt')
-        with open(roster_path, 'w', encoding='utf-8') as f:
-            f.write("=" * 80 + "\n")
-            f.write("코딩 에이전트 릴레이 챌린지 - 조별 주자 순서 (비상용)\n")
-            f.write("=" * 80 + "\n")
-            f.write("※ 시스템 장애 시 이 파일을 보고 수동으로 진행할 수 있습니다.\n")
-            f.write("※ 정답이 포함되어 있으므로 참가자에게 공유하지 마세요.\n")
-            f.write("=" * 80 + "\n\n")
-            for g_id, members in group_roster.items():
-                f.write(f"[ 조 {g_id} ]\n")
-                f.write(f"{'순서':>4}  {'이름':<20}  {'Knox-ID':<20}  {'정답'}\n")
-                f.write("-" * 70 + "\n")
-                for m in members:
-                    f.write(f"{m['order']:>4}  {m['name']:<20}  {m['knox_id']:<20}  {m['answer']}\n")
-                f.write("\n")
-            f.write("=" * 80 + "\n")
+        _write_roster_file(group_roster, roster_path)
         print(f"groupRoster.txt 생성 완료")
 
-        # 7. 요약 출력
+        # 5. 요약
         print("\n" + "=" * 60)
         print("초기화 완료 요약")
         print("=" * 60)
         for line in first_player_lines:
             print(f"  {line}")
         print(f"\n[조별 주자 순서] groupRoster.txt에 저장됨")
-        print("  → 시스템 장애 시 수동 진행용 (정답 포함)")
         print("=" * 60)
+
+    return {
+        'first_player_lines': first_player_lines,
+        'roster_path': roster_path,
+        'runners': total,
+        'groups': group_count,
+    }
 
 
 if __name__ == '__main__':

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -3,10 +3,40 @@
 {% block title %}관리자 대시보드{% endblock %}
 
 {% block content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h2 style="font-weight: 800;">관리자 대시보드</h2>
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
+    <div class="d-flex align-items-center gap-3">
+        <h2 class="mb-0" style="font-weight: 800;">관리자 대시보드</h2>
+        {% if not initialized %}
+        <span class="badge bg-secondary" style="font-size: 0.85rem; padding: 0.5rem 0.75rem;">
+            ⚠ 초기화 필요
+        </span>
+        {% elif challenge_opened %}
+        <span class="badge bg-success" style="font-size: 0.85rem; padding: 0.5rem 0.75rem;">
+            🟢 공개 중
+        </span>
+        {% else %}
+        <span class="badge bg-warning" style="font-size: 0.85rem; padding: 0.5rem 0.75rem; color: #000;">
+            🔒 비공개 (준비 중)
+        </span>
+        {% endif %}
+    </div>
     <div>
         <span style="color: var(--text-secondary); font-size: 0.85rem;" id="auto-refresh-status">5초마다 자동 갱신</span>
+        {% if initialized %}
+        <form method="POST" action="{{ url_for('admin_toggle_open') }}" class="d-inline ms-2">
+            {% if challenge_opened %}
+            <button type="submit" class="btn btn-outline-warning btn-sm"
+                    onclick="return confirm('챌린지를 비공개로 전환할까요? 참가자들이 즉시 준비 중 페이지를 보게 됩니다.');">
+                🔒 비공개로 전환
+            </button>
+            {% else %}
+            <button type="submit" class="btn btn-success btn-sm"
+                    onclick="return confirm('챌린지를 공개할까요? 참가자들이 즉시 접속 가능해집니다.');">
+                🟢 공개하기
+            </button>
+            {% endif %}
+        </form>
+        {% endif %}
         <button type="button" class="btn btn-outline-secondary btn-sm ms-2" id="btn-view-first-player">firstPlayer.txt</button>
         <button type="button" class="btn btn-outline-secondary btn-sm ms-1" id="btn-view-roster">groupRoster.txt</button>
         <a href="{{ url_for('admin_init_download', kind='challenge-data') }}" class="btn btn-outline-secondary btn-sm ms-1">challenge_data.dat</a>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -10,6 +10,7 @@
         <button type="button" class="btn btn-outline-secondary btn-sm ms-2" id="btn-view-first-player">firstPlayer.txt</button>
         <button type="button" class="btn btn-outline-secondary btn-sm ms-1" id="btn-view-roster">groupRoster.txt</button>
         <a href="{{ url_for('admin_init_download', kind='challenge-data') }}" class="btn btn-outline-secondary btn-sm ms-1">challenge_data.dat</a>
+        <a href="{{ url_for('admin_init_download', kind='relay-db') }}" class="btn btn-outline-secondary btn-sm ms-1" title="SQLite DB 스냅샷">relay.db</a>
         <a href="{{ url_for('admin_init') }}" class="btn btn-outline-primary btn-sm ms-2">초기화 마법사</a>
         <a href="{{ url_for('admin_logout') }}" class="btn btn-outline-secondary btn-sm ms-2">로그아웃</a>
     </div>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -7,6 +7,9 @@
     <h2 style="font-weight: 800;">관리자 대시보드</h2>
     <div>
         <span style="color: var(--text-secondary); font-size: 0.85rem;" id="auto-refresh-status">5초마다 자동 갱신</span>
+        <button type="button" class="btn btn-outline-secondary btn-sm ms-2" id="btn-view-first-player">firstPlayer.txt</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm ms-1" id="btn-view-roster">groupRoster.txt</button>
+        <a href="{{ url_for('admin_init_download', kind='challenge-data') }}" class="btn btn-outline-secondary btn-sm ms-1">challenge_data.dat</a>
         <a href="{{ url_for('admin_init') }}" class="btn btn-outline-primary btn-sm ms-2">초기화 마법사</a>
         <a href="{{ url_for('admin_logout') }}" class="btn btn-outline-secondary btn-sm ms-2">로그아웃</a>
     </div>
@@ -14,6 +17,50 @@
 
 <div id="admin-dashboard-data">
     {% include "_admin_groups.html" %}
+</div>
+
+<!-- groupRoster.txt 모달 (정답 포함 - 취급 주의) -->
+<div class="modal fade" id="rosterModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-xl">
+    <div class="modal-content" style="background: var(--card-bg, #fff); color: var(--text-primary, #000);">
+      <div class="modal-header">
+        <h5 class="modal-title">groupRoster.txt <span style="color: #ef4444; font-size: 0.85rem; font-weight: 400;">· 정답 포함 · 공유 금지</span></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        <div class="d-flex gap-2 mb-2">
+          <button type="button" class="btn btn-outline-primary btn-sm" id="btn-copy-roster">📋 전체 복사</button>
+          <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('admin_init_download', kind='roster') }}">💾 다운로드</a>
+        </div>
+        <pre id="roster-content"
+             style="background: rgba(0,0,0,0.4); padding: 1rem; border-radius: 8px;
+                    font-family: 'D2Coding', Consolas, monospace; font-size: 0.85rem;
+                    max-height: 600px; overflow-y: auto; white-space: pre-wrap;"></pre>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- firstPlayer.txt 모달 -->
+<div class="modal fade" id="firstPlayerModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content" style="background: var(--card-bg, #fff); color: var(--text-primary, #000);">
+      <div class="modal-header">
+        <h5 class="modal-title">firstPlayer.txt</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        <div class="d-flex gap-2 mb-2">
+          <button type="button" class="btn btn-outline-primary btn-sm" id="btn-copy-first-player">📋 전체 복사</button>
+          <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('admin_init_download', kind='first-player') }}">💾 다운로드</a>
+        </div>
+        <pre id="first-player-content"
+             style="background: rgba(0,0,0,0.4); padding: 1rem; border-radius: 8px;
+                    font-family: 'D2Coding', Consolas, monospace; font-size: 0.85rem;
+                    max-height: 500px; overflow-y: auto; white-space: pre-wrap;"></pre>
+      </div>
+    </div>
+  </div>
 </div>
 
 <!-- Reason 입력 모달 -->
@@ -125,6 +172,66 @@
     });
 
     setInterval(refreshPartial, 5000);
+
+    // firstPlayer.txt 모달
+    const firstPlayerModal = new bootstrap.Modal(document.getElementById('firstPlayerModal'));
+    const firstPlayerContent = document.getElementById('first-player-content');
+    document.getElementById('btn-view-first-player').addEventListener('click', async () => {
+        firstPlayerContent.textContent = '불러오는 중...';
+        firstPlayerModal.show();
+        try {
+            const res = await fetch('{{ url_for("admin_init_download", kind="first-player") }}', {
+                credentials: 'same-origin'
+            });
+            if (res.status === 404) {
+                firstPlayerContent.textContent = 'firstPlayer.txt가 없습니다. 초기화 마법사를 먼저 실행하세요.';
+                return;
+            }
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            firstPlayerContent.textContent = await res.text();
+        } catch (e) {
+            firstPlayerContent.textContent = '로드 실패: ' + e.message;
+        }
+    });
+    document.getElementById('btn-copy-first-player').addEventListener('click', () => {
+        const text = firstPlayerContent.textContent;
+        navigator.clipboard.writeText(text).then(() => {
+            const btn = document.getElementById('btn-copy-first-player');
+            const orig = btn.textContent;
+            btn.textContent = '✔ 복사됨';
+            setTimeout(() => { btn.textContent = orig; }, 1500);
+        });
+    });
+
+    // groupRoster.txt 모달 (정답 포함)
+    const rosterModal = new bootstrap.Modal(document.getElementById('rosterModal'));
+    const rosterContent = document.getElementById('roster-content');
+    document.getElementById('btn-view-roster').addEventListener('click', async () => {
+        rosterContent.textContent = '불러오는 중...';
+        rosterModal.show();
+        try {
+            const res = await fetch('{{ url_for("admin_init_download", kind="roster") }}', {
+                credentials: 'same-origin'
+            });
+            if (res.status === 404) {
+                rosterContent.textContent = 'groupRoster.txt가 없습니다. 초기화 마법사를 먼저 실행하세요.';
+                return;
+            }
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            rosterContent.textContent = await res.text();
+        } catch (e) {
+            rosterContent.textContent = '로드 실패: ' + e.message;
+        }
+    });
+    document.getElementById('btn-copy-roster').addEventListener('click', () => {
+        const text = rosterContent.textContent;
+        navigator.clipboard.writeText(text).then(() => {
+            const btn = document.getElementById('btn-copy-roster');
+            const orig = btn.textContent;
+            btn.textContent = '✔ 복사됨';
+            setTimeout(() => { btn.textContent = orig; }, 1500);
+        });
+    });
 })();
 </script>
 {% endblock %}

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -7,6 +7,7 @@
     <h2 style="font-weight: 800;">관리자 대시보드</h2>
     <div>
         <span style="color: var(--text-secondary); font-size: 0.85rem;" id="auto-refresh-status">5초마다 자동 갱신</span>
+        <a href="{{ url_for('admin_init') }}" class="btn btn-outline-primary btn-sm ms-2">초기화 마법사</a>
         <a href="{{ url_for('admin_logout') }}" class="btn btn-outline-secondary btn-sm ms-2">로그아웃</a>
     </div>
 </div>

--- a/templates/admin_init.html
+++ b/templates/admin_init.html
@@ -345,6 +345,13 @@
   // ----- 2단계: 주자 목록 렌더 -----
   function renderRoster() {
     const container = el('roster-groups');
+    // 재렌더 전 펼침 상태 캡처
+    const expandedGroups = new Set();
+    container.querySelectorAll('.accordion-collapse.show').forEach(el => {
+      const m = el.id.match(/^grp-body-(\d+)$/);
+      if (m) expandedGroups.add(parseInt(m[1], 10));
+    });
+
     container.innerHTML = '';
     // 조별 그룹핑 (group 번호 순)
     const byGroup = {};
@@ -361,6 +368,7 @@
       const members = byGroup[g];
       const size = state.groupSizes[g - 1];
       const mismatch = members.length !== size;
+      const isOpen = expandedGroups.has(g);
       const acc = document.createElement('div');
       acc.className = 'accordion-item';
       acc.style.background = 'rgba(255,255,255,0.03)';
@@ -368,13 +376,13 @@
       acc.style.marginBottom = '0.5rem';
       acc.innerHTML = `
         <h2 class="accordion-header">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+          <button class="accordion-button ${isOpen ? '' : 'collapsed'}" type="button" data-bs-toggle="collapse"
                   data-bs-target="#grp-body-${g}" style="background: transparent; color: var(--text-primary); font-weight: 600;">
             조 ${g} (${members.length}명${mismatch ? ' / 정원 ' + size : ''})
             ${mismatch ? '<span style="color: #ef4444; margin-left: 0.5rem;">정원 불일치</span>' : ''}
           </button>
         </h2>
-        <div id="grp-body-${g}" class="accordion-collapse collapse">
+        <div id="grp-body-${g}" class="accordion-collapse collapse${isOpen ? ' show' : ''}">
           <div class="accordion-body p-2">
             <table class="table table-sm table-dark-custom mb-0">
               <thead>
@@ -483,15 +491,16 @@
 
   function moveToGroup(idx, targetGroup) {
     const flat = rebuildFlat();
-    // 해당 원소를 flat에서 빼서 targetGroup의 끝 자리에 삽입
-    const m = flat.splice(idx, 1)[0];
-    // targetGroup의 시작 인덱스 계산
-    let pos = 0;
-    for (let g = 1; g < targetGroup; g++) pos += state.groupSizes[g - 1];
-    pos += state.groupSizes[targetGroup - 1]; // 해당 조의 끝
-    // 하지만 splice 후 전체 길이가 줄었으므로 pos는 최대 flat.length
-    pos = Math.min(pos, flat.length);
-    flat.splice(pos, 0, m);
+    // targetGroup의 첫 슬롯 인덱스 (sum(groupSizes[0..targetGroup-2]))
+    let firstOfTarget = 0;
+    for (let g = 0; g < targetGroup - 1; g++) firstOfTarget += state.groupSizes[g];
+    if (idx === firstOfTarget) {
+      // 이미 target 조의 1번 주자 → no-op (드롭다운 상태 재렌더만)
+      renderRoster();
+      return;
+    }
+    // A와 target 조의 1번 주자를 교환: 두 주자의 자리를 서로 바꿈
+    [flat[idx], flat[firstOfTarget]] = [flat[firstOfTarget], flat[idx]];
     state.participants = assignToGroups(
       flat.map(p => ({knox_id: p.knox_id, name: p.name})),
       state.groupSizes

--- a/templates/admin_init.html
+++ b/templates/admin_init.html
@@ -1,0 +1,659 @@
+{% extends "base.html" %}
+
+{% block title %}챌린지 초기화 마법사{% endblock %}
+
+{% block head %}
+<style>
+  .wizard-steps { display: flex; gap: 0.5rem; margin-bottom: 2rem; }
+  .wizard-step {
+    flex: 1; padding: 0.75rem; border-radius: 8px;
+    background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1);
+    color: var(--text-secondary); text-align: center;
+  }
+  .wizard-step.active {
+    background: rgba(65,105,225,0.15); border-color: rgba(65,105,225,0.6);
+    color: var(--samsung-blue-light); font-weight: 700;
+  }
+  .wizard-step.done { background: rgba(34,197,94,0.1); border-color: rgba(34,197,94,0.4); color: var(--accent-green); }
+  .size-box {
+    background: rgba(65,105,225,0.08); border: 1px solid rgba(65,105,225,0.3);
+    border-radius: 8px; padding: 0.75rem 1rem; margin-top: 0.75rem;
+    font-family: 'D2Coding', Consolas, monospace; font-size: 0.9rem;
+  }
+  .size-box .size-title { color: var(--samsung-blue-light); font-weight: 700; margin-bottom: 0.35rem; }
+  .size-box .size-detail { color: var(--text-secondary); font-size: 0.85rem; }
+  .warn-banner {
+    background: rgba(245,158,11,0.08); border: 1px solid rgba(245,158,11,0.35);
+    border-radius: 8px; padding: 0.6rem 0.9rem; color: #f59e0b;
+    font-size: 0.9rem; margin-top: 0.75rem;
+  }
+  textarea.csv-input {
+    font-family: 'D2Coding', Consolas, monospace; font-size: 0.85rem;
+    min-height: 300px;
+  }
+  .error-list { color: #ef4444; font-size: 0.85rem; }
+  .error-list li { margin-bottom: 0.2rem; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-10">
+    <div class="hero" style="padding: 1.5rem 0;">
+      <h1>챌린지 초기화 마법사</h1>
+      <p>참가자 CSV를 붙여넣어 조를 편성하고 DB를 초기화합니다.</p>
+    </div>
+
+    <div class="wizard-steps">
+      <div class="wizard-step active" id="step-indicator-1">1. 규모 + CSV</div>
+      <div class="wizard-step" id="step-indicator-2">2. 순서 편집</div>
+      <div class="wizard-step" id="step-indicator-3">3. 확인 & 실행</div>
+    </div>
+
+    <!-- ============ 1단계 ============ -->
+    <section id="step-1" class="card mb-4">
+      <div class="card-header py-3"><h5 class="mb-0" style="font-weight: 700;">1단계: 규모 설정 + CSV 붙여넣기</h5></div>
+      <div class="card-body">
+
+        <div class="row g-3">
+          <div class="col-md-4">
+            <label class="form-label" style="font-weight: 600;">전체 인원수 (N)</label>
+            <input type="number" class="form-control" id="input-n"
+                   value="{{ default_n }}" min="{{ n_min }}" max="{{ n_max }}">
+            <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
+              범위: {{ n_min }} ~ {{ n_max }}
+            </div>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label" style="font-weight: 600;">조 수 (G)</label>
+            <input type="number" class="form-control" id="input-g"
+                   value="{{ default_g }}" min="{{ g_min }}" max="{{ g_max }}">
+            <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
+              범위: {{ g_min }} ~ {{ g_max }}, G ≤ N
+            </div>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label" style="font-weight: 600;">현재 문제 풀</label>
+            <div class="form-control-plaintext" id="pool-info">
+              {{ problem_pool_size }}개
+            </div>
+          </div>
+        </div>
+
+        <div class="size-box" id="size-box"></div>
+        <div class="warn-banner" id="pool-warn" style="display: none;"></div>
+
+        <hr class="my-4">
+
+        <label class="form-label" style="font-weight: 600;">참가자 CSV</label>
+        <div style="color: var(--text-secondary); font-size: 0.85rem; margin-bottom: 0.5rem;">
+          기대 컬럼: <code>knox_id</code>, <code>name</code>. 구분자는 쉼표 또는 탭(엑셀 복붙). 헤더는 자동 감지됩니다.
+        </div>
+        <textarea class="form-control csv-input" id="csv-input"
+                  placeholder="knox_id,name&#10;alice.kim,김앨리스&#10;bob.lee,이밥&#10;..."></textarea>
+
+        <div id="parse-errors" class="mt-3" style="display: none;">
+          <div class="alert alert-danger">
+            <strong>파싱 오류:</strong>
+            <ul class="error-list mb-0" id="parse-errors-list"></ul>
+          </div>
+        </div>
+
+        <div class="d-flex justify-content-end mt-3">
+          <button type="button" class="btn btn-samsung px-4 py-2" id="btn-parse">
+            파싱 &amp; 다음 ▶
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ 2단계 ============ -->
+    <section id="step-2" class="card mb-4" style="display: none;">
+      <div class="card-header py-3 d-flex justify-content-between align-items-center">
+        <h5 class="mb-0" style="font-weight: 700;">2단계: 주자 목록 편집</h5>
+        <div id="roster-summary" style="font-size: 0.9rem;"></div>
+      </div>
+      <div class="card-body">
+        <div class="d-flex flex-wrap gap-2 mb-3">
+          <button type="button" class="btn btn-outline-primary btn-sm" id="btn-shuffle-all">🎲 전체 셔플</button>
+          <button type="button" class="btn btn-outline-primary btn-sm" id="btn-shuffle-inner">🎲 조 내부 셔플</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm" id="btn-reset-roster">↻ 초기 상태 복원</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm" id="btn-expand-all">⤵ 모두 펼치기</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm" id="btn-collapse-all">⤴ 모두 접기</button>
+        </div>
+
+        <div id="roster-groups" class="accordion" style="--bs-accordion-bg: transparent;"></div>
+
+        <div class="d-flex justify-content-between mt-3">
+          <button type="button" class="btn btn-outline-secondary" id="btn-back-to-1">◀ 이전</button>
+          <button type="button" class="btn btn-samsung px-4" id="btn-goto-3">다음 ▶</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ 3단계 ============ -->
+    <section id="step-3" class="card mb-4" style="display: none;">
+      <div class="card-header py-3"><h5 class="mb-0" style="font-weight: 700;">3단계: 확인 &amp; 실행</h5></div>
+      <div class="card-body">
+        <table class="table table-dark-custom mb-3" style="width: auto;">
+          <tbody id="summary-table"></tbody>
+        </table>
+
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="checkbox" id="opt-regen">
+          <label class="form-check-label" for="opt-regen">
+            challenge_data.dat 및 xlsx 가이드 재생성
+          </label>
+          <div style="color: var(--text-secondary); font-size: 0.8rem;">
+            N이 현재 문제 풀과 다를 때 자동 체크되며 해제할 수 없습니다.
+          </div>
+        </div>
+
+        <div class="form-check mb-3" id="force-wrap" style="display: none;">
+          <input class="form-check-input" type="checkbox" id="opt-force">
+          <label class="form-check-label" for="opt-force" style="color: #f59e0b;">
+            진행 중인 주자가 있어도 강제 실행
+          </label>
+        </div>
+
+        <hr>
+
+        <div class="mb-3">
+          <label class="form-label" style="font-weight: 600;">
+            확인을 위해 <code>INIT</code> 을 정확히 입력하세요
+          </label>
+          <input type="text" class="form-control" id="confirm-input"
+                 style="max-width: 300px; font-family: 'D2Coding', Consolas, monospace;">
+        </div>
+
+        <div id="commit-result" class="mt-3"></div>
+
+        <div class="d-flex justify-content-between mt-3">
+          <button type="button" class="btn btn-outline-secondary" id="btn-back-to-2">◀ 이전</button>
+          <button type="button" class="btn btn-danger px-4" id="btn-commit" disabled>
+            🗑 초기화 실행
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ 결과 화면 ============ -->
+    <section id="step-done" class="card mb-4" style="display: none;">
+      <div class="card-header py-3"><h5 class="mb-0" style="font-weight: 700; color: var(--accent-green);">초기화 완료</h5></div>
+      <div class="card-body">
+        <div id="done-summary" class="mb-3"></div>
+
+        <h6 style="font-weight: 700; margin-top: 1.5rem;">firstPlayer.txt</h6>
+        <div style="color: var(--text-secondary); font-size: 0.85rem; margin-bottom: 0.5rem;">
+          각 조 1번 주자에게 개별적으로 전달하세요.
+        </div>
+        <div class="d-flex gap-2 mb-2">
+          <button type="button" class="btn btn-outline-primary btn-sm" id="btn-copy-first">📋 전체 복사</button>
+          <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('admin_init_download', kind='first-player') }}">💾 firstPlayer.txt</a>
+          <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('admin_init_download', kind='roster') }}">💾 groupRoster.txt</a>
+          <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('admin_init_download', kind='challenge-data') }}">💾 challenge_data.dat</a>
+        </div>
+        <pre id="done-first-player"
+             style="background: rgba(0,0,0,0.4); padding: 1rem; border-radius: 8px;
+                    font-family: 'D2Coding', Consolas, monospace; font-size: 0.85rem;
+                    max-height: 400px; overflow-y: auto;"></pre>
+
+        <div class="mt-3">
+          <a href="{{ url_for('admin_dashboard') }}" class="btn btn-samsung">관리자 대시보드로 이동 →</a>
+        </div>
+      </div>
+    </section>
+
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+  const N_MIN = {{ n_min }}, N_MAX = {{ n_max }};
+  const G_MIN = {{ g_min }}, G_MAX = {{ g_max }};
+  const POOL_SIZE = {{ problem_pool_size }};
+
+  const el = (id) => document.getElementById(id);
+
+  // 전역 상태
+  const state = {
+    N: 0, G: 0,
+    groupSizes: [],
+    participants: [],          // [{knox_id, name, group, order}]
+    initialSnapshot: null,     // 파싱 직후 참가자 원본 (초기 복원용)
+    commitResult: null,        // {first_player_lines, ...}
+  };
+
+  function computeGroupSizes(n, g) {
+    const base = Math.floor(n / g);
+    const remainder = n % g;
+    return Array.from({length: g}, (_, i) => i < remainder ? base + 1 : base);
+  }
+
+  // ----- 1단계: 규모 박스 실시간 렌더 -----
+  function renderSizeBox() {
+    const sizeBox = el('size-box'), poolWarn = el('pool-warn');
+    const n = parseInt(el('input-n').value, 10);
+    const g = parseInt(el('input-g').value, 10);
+    if (!Number.isInteger(n) || !Number.isInteger(g) || n < N_MIN || g < G_MIN) {
+      sizeBox.innerHTML = '<span style="color: var(--text-secondary);">N/G를 입력하세요.</span>';
+      return;
+    }
+    if (g > n) {
+      sizeBox.innerHTML = '<span style="color: #ef4444;">조 수가 전체 인원수보다 큽니다.</span>';
+      return;
+    }
+    const base = Math.floor(n / g), remainder = n % g;
+    sizeBox.innerHTML = remainder === 0
+      ? `<div class="size-title">조당 인원: 각 조 ${base}명 (총 ${n}명, 균등 배분)</div>`
+      : `<div class="size-title">조당 인원: ${base}~${base + 1}명</div>`
+        + `<div class="size-detail">· 조 1~${remainder}: ${base + 1}명</div>`
+        + `<div class="size-detail">· 조 ${remainder + 1}~${g}: ${base}명</div>`
+        + `<div class="size-detail">· 총 ${n}명</div>`;
+    if (n > POOL_SIZE) {
+      poolWarn.style.display = 'block';
+      poolWarn.textContent = `⚠ N=${n}이 현재 문제 풀(${POOL_SIZE}개)보다 큽니다. 3단계에서 "challenge_data.dat 재생성"이 자동으로 체크됩니다.`;
+    } else {
+      poolWarn.style.display = 'none';
+    }
+  }
+  el('input-n').addEventListener('input', renderSizeBox);
+  el('input-g').addEventListener('input', renderSizeBox);
+  renderSizeBox();
+
+  // ----- 단계 전환 -----
+  function goStep(n) {
+    for (const s of [1,2,3]) {
+      el('step-' + s).style.display = n === s ? '' : 'none';
+      const ind = el('step-indicator-' + s);
+      ind.classList.remove('active', 'done');
+      if (s < n) ind.classList.add('done');
+      else if (s === n) ind.classList.add('active');
+    }
+    el('step-done').style.display = 'none';
+  }
+  function goDone() {
+    for (const s of [1,2,3]) {
+      el('step-' + s).style.display = 'none';
+      el('step-indicator-' + s).classList.remove('active');
+      el('step-indicator-' + s).classList.add('done');
+    }
+    el('step-done').style.display = '';
+  }
+
+  // ----- 1단계 → 파싱 → 2단계 -----
+  el('btn-parse').addEventListener('click', async () => {
+    const n = parseInt(el('input-n').value, 10);
+    const g = parseInt(el('input-g').value, 10);
+    const csvText = el('csv-input').value;
+    const errorsBox = el('parse-errors'), errorsList = el('parse-errors-list');
+    errorsBox.style.display = 'none';
+    errorsList.innerHTML = '';
+
+    try {
+      const res = await fetch('{{ url_for("admin_init_parse") }}', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        body: JSON.stringify({csv_text: csvText, total_n: n, group_count: g}),
+      });
+      const data = await res.json();
+      if (!data.ok) {
+        errorsBox.style.display = 'block';
+        for (const e of (data.errors || [])) {
+          const li = document.createElement('li');
+          li.textContent = e.row > 0 ? `행 ${e.row}: ${e.message}` : e.message;
+          errorsList.appendChild(li);
+        }
+        return;
+      }
+
+      // 경고가 있으면 사용자 확인
+      if (data.warnings && data.warnings.length) {
+        if (!confirm(data.warnings.join('\n\n') + '\n\n계속 진행할까요?')) return;
+      }
+
+      state.N = data.participants.length;
+      state.G = data.group_sizes.length;
+      state.groupSizes = data.group_sizes.slice();
+      // 조 배정: 파싱된 순서 그대로, 정원만큼 잘라서
+      state.participants = assignToGroups(data.participants, state.groupSizes);
+      state.initialSnapshot = state.participants.map(p => ({...p}));
+      renderRoster();
+      goStep(2);
+    } catch (err) {
+      errorsBox.style.display = 'block';
+      const li = document.createElement('li');
+      li.textContent = '요청 실패: ' + (err && err.message ? err.message : String(err));
+      errorsList.appendChild(li);
+    }
+  });
+
+  function assignToGroups(flat, groupSizes) {
+    const result = [];
+    let idx = 0;
+    for (let g = 0; g < groupSizes.length; g++) {
+      for (let o = 1; o <= groupSizes[g]; o++) {
+        const m = flat[idx++];
+        result.push({knox_id: m.knox_id, name: m.name, group: g + 1, order: o});
+      }
+    }
+    return result;
+  }
+
+  // ----- 2단계: 주자 목록 렌더 -----
+  function renderRoster() {
+    const container = el('roster-groups');
+    container.innerHTML = '';
+    // 조별 그룹핑 (group 번호 순)
+    const byGroup = {};
+    for (let g = 1; g <= state.G; g++) byGroup[g] = [];
+    state.participants.forEach(p => byGroup[p.group].push(p));
+    // run_order 정렬 + 재번호
+    for (let g = 1; g <= state.G; g++) {
+      byGroup[g].sort((a, b) => a.order - b.order);
+      byGroup[g].forEach((p, i) => p.order = i + 1);
+    }
+
+    // 아코디언 렌더
+    for (let g = 1; g <= state.G; g++) {
+      const members = byGroup[g];
+      const size = state.groupSizes[g - 1];
+      const mismatch = members.length !== size;
+      const acc = document.createElement('div');
+      acc.className = 'accordion-item';
+      acc.style.background = 'rgba(255,255,255,0.03)';
+      acc.style.border = '1px solid rgba(255,255,255,0.1)';
+      acc.style.marginBottom = '0.5rem';
+      acc.innerHTML = `
+        <h2 class="accordion-header">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                  data-bs-target="#grp-body-${g}" style="background: transparent; color: var(--text-primary); font-weight: 600;">
+            조 ${g} (${members.length}명${mismatch ? ' / 정원 ' + size : ''})
+            ${mismatch ? '<span style="color: #ef4444; margin-left: 0.5rem;">정원 불일치</span>' : ''}
+          </button>
+        </h2>
+        <div id="grp-body-${g}" class="accordion-collapse collapse">
+          <div class="accordion-body p-2">
+            <table class="table table-sm table-dark-custom mb-0">
+              <thead>
+                <tr>
+                  <th style="width: 60px;">순서</th>
+                  <th>Knox-ID</th>
+                  <th>이름</th>
+                  <th style="width: 200px;">조작</th>
+                </tr>
+              </thead>
+              <tbody data-group="${g}">
+                ${members.map(p => renderMemberRow(p, state.G)).join('')}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      `;
+      container.appendChild(acc);
+    }
+
+    renderRosterSummary();
+    wireMemberActions();
+  }
+
+  function renderMemberRow(p, G) {
+    const isFirst = p.order === 1;
+    const options = Array.from({length: G}, (_, i) => i + 1)
+      .map(n => `<option value="${n}" ${n === p.group ? 'selected' : ''}>조 ${n}</option>`).join('');
+    return `
+      <tr data-knox="${p.knox_id}" ${isFirst ? 'style="background: rgba(245,158,11,0.08);"' : ''}>
+        <td style="font-weight: 600;">${isFirst ? '⭐ ' : ''}${p.order}</td>
+        <td style="font-family: 'D2Coding', Consolas, monospace; font-size: 0.85rem;">${escapeHtml(p.knox_id)}</td>
+        <td>${escapeHtml(p.name)}</td>
+        <td>
+          <button class="btn btn-sm btn-outline-secondary js-up" title="위로">▲</button>
+          <button class="btn btn-sm btn-outline-secondary js-down" title="아래로">▼</button>
+          <select class="form-select form-select-sm d-inline-block js-move-group" style="width: 90px;">
+            ${options}
+          </select>
+        </td>
+      </tr>
+    `;
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+
+  function renderRosterSummary() {
+    const total = state.participants.length;
+    const expected = state.N;
+    const ok = total === expected;
+    el('roster-summary').innerHTML = ok
+      ? `<span style="color: var(--accent-green);">✔ 조 ${state.G}개, 총 ${total}명 (정합)</span>`
+      : `<span style="color: #ef4444;">✘ 총 ${total}명 / 기대 ${expected}명</span>`;
+  }
+
+  function wireMemberActions() {
+    // 평면 배열에서 위/아래 swap (조 경계는 정원 제약 없이 넘음: 새 조에 편입)
+    el('roster-groups').querySelectorAll('.js-up').forEach(btn => {
+      btn.onclick = (e) => moveMember(findIndexOf(e.target), -1);
+    });
+    el('roster-groups').querySelectorAll('.js-down').forEach(btn => {
+      btn.onclick = (e) => moveMember(findIndexOf(e.target), 1);
+    });
+    el('roster-groups').querySelectorAll('.js-move-group').forEach(sel => {
+      sel.onchange = (e) => {
+        const idx = findIndexOf(e.target);
+        const target = parseInt(e.target.value, 10);
+        moveToGroup(idx, target);
+      };
+    });
+  }
+
+  function findIndexOf(node) {
+    const tr = node.closest('tr');
+    const knox = tr.getAttribute('data-knox');
+    return state.participants.findIndex(p => p.knox_id === knox);
+  }
+
+  function rebuildFlat() {
+    // 조별·순서대로 평면 배열 재구성
+    const byGroup = {};
+    for (let g = 1; g <= state.G; g++) byGroup[g] = [];
+    state.participants.forEach(p => byGroup[p.group].push(p));
+    const flat = [];
+    for (let g = 1; g <= state.G; g++) {
+      byGroup[g].sort((a, b) => a.order - b.order);
+      byGroup[g].forEach((p, i) => { p.order = i + 1; flat.push(p); });
+    }
+    return flat;
+  }
+
+  function moveMember(idx, delta) {
+    const flat = rebuildFlat();
+    const target = idx + delta;
+    if (target < 0 || target >= flat.length) return;
+    [flat[idx], flat[target]] = [flat[target], flat[idx]];
+    // 정원에 맞춰 조·순서 재할당
+    state.participants = assignToGroups(
+      flat.map(p => ({knox_id: p.knox_id, name: p.name})),
+      state.groupSizes
+    );
+    renderRoster();
+  }
+
+  function moveToGroup(idx, targetGroup) {
+    const flat = rebuildFlat();
+    // 해당 원소를 flat에서 빼서 targetGroup의 끝 자리에 삽입
+    const m = flat.splice(idx, 1)[0];
+    // targetGroup의 시작 인덱스 계산
+    let pos = 0;
+    for (let g = 1; g < targetGroup; g++) pos += state.groupSizes[g - 1];
+    pos += state.groupSizes[targetGroup - 1]; // 해당 조의 끝
+    // 하지만 splice 후 전체 길이가 줄었으므로 pos는 최대 flat.length
+    pos = Math.min(pos, flat.length);
+    flat.splice(pos, 0, m);
+    state.participants = assignToGroups(
+      flat.map(p => ({knox_id: p.knox_id, name: p.name})),
+      state.groupSizes
+    );
+    renderRoster();
+  }
+
+  // 셔플
+  function fisherYates(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  el('btn-shuffle-all').onclick = () => {
+    const flat = rebuildFlat().map(p => ({knox_id: p.knox_id, name: p.name}));
+    fisherYates(flat);
+    state.participants = assignToGroups(flat, state.groupSizes);
+    renderRoster();
+  };
+
+  el('btn-shuffle-inner').onclick = () => {
+    const byGroup = {};
+    for (let g = 1; g <= state.G; g++) byGroup[g] = [];
+    state.participants.forEach(p => byGroup[p.group].push(p));
+    const flat = [];
+    for (let g = 1; g <= state.G; g++) {
+      const arr = byGroup[g].map(p => ({knox_id: p.knox_id, name: p.name}));
+      fisherYates(arr);
+      flat.push(...arr);
+    }
+    state.participants = assignToGroups(flat, state.groupSizes);
+    renderRoster();
+  };
+
+  el('btn-reset-roster').onclick = () => {
+    if (!confirm('파싱 직후 상태로 되돌릴까요? 모든 편집이 사라집니다.')) return;
+    state.participants = state.initialSnapshot.map(p => ({...p}));
+    renderRoster();
+  };
+
+  el('btn-expand-all').onclick = () => {
+    document.querySelectorAll('#roster-groups .accordion-collapse').forEach(c => c.classList.add('show'));
+    document.querySelectorAll('#roster-groups .accordion-button').forEach(b => b.classList.remove('collapsed'));
+  };
+  el('btn-collapse-all').onclick = () => {
+    document.querySelectorAll('#roster-groups .accordion-collapse').forEach(c => c.classList.remove('show'));
+    document.querySelectorAll('#roster-groups .accordion-button').forEach(b => b.classList.add('collapsed'));
+  };
+
+  el('btn-back-to-1').onclick = () => goStep(1);
+  el('btn-goto-3').onclick = () => {
+    renderSummary();
+    goStep(3);
+  };
+  el('btn-back-to-2').onclick = () => goStep(2);
+
+  // ----- 3단계: 요약 + 실행 -----
+  function renderSummary() {
+    const need = state.N;
+    const rows = [
+      ['조 수', state.G],
+      ['전체 인원', `${state.N}명`],
+      ['조당 인원', summarizeGroupSizes(state.groupSizes)],
+      ['필요 문제 수', `${need}개`],
+      ['현재 문제 풀', `${POOL_SIZE}개`],
+    ];
+    el('summary-table').innerHTML = rows.map(([k, v]) =>
+      `<tr><th style="width: 180px;">${k}</th><td>${v}</td></tr>`
+    ).join('');
+
+    // regen 자동 체크
+    const optRegen = el('opt-regen');
+    if (need !== POOL_SIZE) {
+      optRegen.checked = true;
+      optRegen.disabled = true;
+    } else {
+      optRegen.checked = false;
+      optRegen.disabled = false;
+    }
+
+    // 진행 중 체크 (서버에서 force 필요시 재시도 - 여기서는 단순히 버튼 노출은 force 필요 시에만)
+    // 일단 숨김, commit 에러 시 노출
+    el('force-wrap').style.display = 'none';
+    el('opt-force').checked = false;
+
+    el('commit-result').innerHTML = '';
+    el('confirm-input').value = '';
+    el('btn-commit').disabled = true;
+  }
+
+  function summarizeGroupSizes(sizes) {
+    const n = sizes.reduce((a, b) => a + b, 0);
+    const g = sizes.length;
+    const base = Math.floor(n / g), remainder = n % g;
+    if (remainder === 0) return `각 조 ${base}명 (균등)`;
+    return `${base}~${base + 1}명 / 조 1~${remainder}: ${base + 1}명, 조 ${remainder + 1}~${g}: ${base}명`;
+  }
+
+  el('confirm-input').addEventListener('input', () => {
+    el('btn-commit').disabled = el('confirm-input').value !== 'INIT';
+  });
+
+  el('btn-commit').onclick = async () => {
+    const btn = el('btn-commit');
+    btn.disabled = true;
+    const origText = btn.textContent;
+    btn.textContent = '실행 중...';
+    el('commit-result').innerHTML = '';
+
+    const body = {
+      group_count: state.G,
+      group_sizes: state.groupSizes,
+      ordered_participants: state.participants,
+      regen_challenge_data: el('opt-regen').checked,
+      force: el('opt-force').checked,
+      confirm: el('confirm-input').value,
+    };
+
+    try {
+      const res = await fetch('{{ url_for("admin_init_commit") }}', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        btn.disabled = false;
+        btn.textContent = origText;
+        if (data.error_code === 'IN_PROGRESS') {
+          el('force-wrap').style.display = 'block';
+          el('commit-result').innerHTML = `<div class="alert alert-warning">${escapeHtml(data.message || '진행 중 주자 있음')}<br>강제 실행 체크 후 재시도.</div>`;
+        } else {
+          el('commit-result').innerHTML = `<div class="alert alert-danger">[${escapeHtml(data.error_code || '')}] ${escapeHtml(data.message || '실행 실패')}</div>`;
+        }
+        return;
+      }
+      state.commitResult = data;
+      renderDone(data);
+    } catch (err) {
+      btn.disabled = false;
+      btn.textContent = origText;
+      el('commit-result').innerHTML = `<div class="alert alert-danger">요청 실패: ${escapeHtml(err.message || String(err))}</div>`;
+    }
+  };
+
+  function renderDone(data) {
+    el('done-summary').innerHTML =
+      `✅ 조 ${data.summary.groups}개 / 주자 ${data.summary.runners}명 / 문제 ${data.summary.problems}개 세팅 완료`;
+    el('done-first-player').textContent = (data.first_player_lines || []).join('\n');
+    goDone();
+  }
+
+  el('btn-copy-first').onclick = () => {
+    const text = el('done-first-player').textContent;
+    navigator.clipboard.writeText(text).then(() => {
+      el('btn-copy-first').textContent = '✔ 복사됨';
+      setTimeout(() => { el('btn-copy-first').textContent = '📋 전체 복사'; }, 1500);
+    });
+  };
+})();
+</script>
+{% endblock %}

--- a/templates/admin_init.html
+++ b/templates/admin_init.html
@@ -209,6 +209,12 @@
                     font-family: 'D2Coding', Consolas, monospace; font-size: 0.85rem;
                     max-height: 400px; overflow-y: auto;"></pre>
 
+        <div class="alert" style="background: rgba(245,158,11,0.08); border: 1px solid rgba(245,158,11,0.35); color: #f59e0b; border-radius: 8px; margin-top: 1.5rem;">
+          <strong>⚠ 챌린지는 현재 비공개 상태입니다.</strong><br>
+          참가자들은 "챌린지 준비 중" 페이지를 보게 됩니다.
+          공식 시작 시각에 관리자 대시보드의 "🟢 공개하기" 버튼을 눌러 주세요.
+        </div>
+
         <div class="mt-3">
           <a href="{{ url_for('admin_dashboard') }}" class="btn btn-samsung">관리자 대시보드로 이동 →</a>
         </div>

--- a/templates/admin_init.html
+++ b/templates/admin_init.html
@@ -149,6 +149,17 @@
           </div>
         </div>
 
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="checkbox" id="opt-show-individual" checked>
+          <label class="form-check-label" for="opt-show-individual">
+            개인 랭킹을 리더보드에 공개
+          </label>
+          <div style="color: var(--text-secondary); font-size: 0.8rem;">
+            체크 시 리더보드 하단에 "개인 랭킹 TOP 10"(경과시간 오름차순)이 표시됩니다.
+            개인 시상을 하지 않는 운영에서는 해제하세요.
+          </div>
+        </div>
+
         <div class="form-check mb-3" id="force-wrap" style="display: none;">
           <input class="form-check-input" type="checkbox" id="opt-force">
           <label class="form-check-label" for="opt-force" style="color: #f59e0b;">
@@ -619,6 +630,7 @@
       ordered_participants: state.participants,
       regen_challenge_data: el('opt-regen').checked,
       force: el('opt-force').checked,
+      show_individual_ranking: el('opt-show-individual').checked,
       confirm: el('confirm-input').value,
     };
 

--- a/templates/coming_soon.html
+++ b/templates/coming_soon.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}챌린지 준비 중{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center" style="margin-top: 4rem;">
+  <div class="col-lg-7 col-md-9">
+    <div class="card" style="text-align: center; padding: 3rem 2rem;">
+      <div style="font-size: 4rem; margin-bottom: 1rem;">⏳</div>
+      <h2 style="font-weight: 800; margin-bottom: 1rem;">챌린지 준비 중입니다</h2>
+      <p style="color: var(--text-secondary); font-size: 1.05rem; line-height: 1.6;">
+        운영자가 챌린지를 공개하면 이 페이지에서 바로 시작하실 수 있습니다.<br>
+        조금만 기다려 주세요.
+      </p>
+      <p style="color: var(--text-secondary); font-size: 0.85rem; margin-top: 1.5rem;">
+        공지된 시작 시각까지 이 페이지를 새로고침하며 대기해 주세요.
+      </p>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+// 30초마다 자동 새로고침 (공개 전환 감지)
+setTimeout(() => { location.reload(); }, 30000);
+</script>
+{% endblock %}

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -106,6 +106,7 @@
     </div>
 </div>
 
+{% if show_individual %}
 <!-- 개인 랭킹 TOP N (동적) -->
 <h4 class="mt-5 mb-3" style="font-weight: 800;">개인 랭킹 TOP {{ individuals|length }}</h4>
 <p style="color: var(--text-secondary); font-size: 0.85rem; margin-top: -0.5rem;">
@@ -155,6 +156,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
Epic: #11

## 요약
- 운영자가 CLI `python init_db.py` 없이 운영 페이지에서 챌린지를 초기화할 수 있는 3단계 마법사 (`/admin/init`)
- 여러 조직에서 순차 재사용 가능: N ≤ 500, G ≤ 50
- CSV 붙여넣기 → 주자 순서 수동 편집(▲▼·조 스왑·셔플) → INIT 타이핑 확인 → 실행
- 관리자 대시보드에서 firstPlayer.txt / groupRoster.txt / challenge_data.dat 언제든 조회·다운로드

## 구현 범위 (이슈)
- #12 `generate_challenge.main(total_problems)` 파라미터화 + 제너레이터 데이터 N 비례 스케일링
- #13 `init_database(group_count, group_sizes, ordered_participants, regen_challenge_data)` 리팩터링, 앱 컨텍스트 재사용
- #14 1단계 UI + `/admin/init/parse` (CSV 파싱, 중복·빈값·범위 검증)
- #15 2단계 주자 목록 편집 UI (조별 아코디언, 이동·셔플, 클라이언트 state)
- #16 3단계 + `/admin/init/commit` + 안전장치 (INIT 타이핑, force, regen 자동 체크)
- #17 결과 화면 + 다운로드 엔드포인트 (firstPlayer.txt 렌더링·복사·다운로드)
- #19 2단계 편집 UI 3건 수정 (off-by-one, swap semantics, 아코디언 펼침 유지)
- #20 관리자 대시보드에서 초기화 산출물 접근 버튼 (firstPlayer/roster 인라인 모달 + challenge_data 다운로드)

## 안전장치
- `INIT` 고정 문자열 타이핑 확인
- `started_at` 있는 주자 존재 시 `force` 필수 (409 `IN_PROGRESS`)
- N > 현재 풀 크기면 regen 자동 체크 + 해제 불가
- 중복 knox_id / 빈 값 차단
- N (2~500), G (2~50), G ≤ N 범위 검증
- DB 트랜잭션 + 실패 롤백

## 테스트 결과
- N=130, 250, 500 각각 정확히 N개 문제 생성 확인
- N=500 + regen 포함 엔드투엔드 3.1초
- Flask test_client로 parse/commit/in_progress/force/download 전 케이스 통과
- CLI `python init_db.py` 하위호환 동작 확인
- 2단계 UI 수동 검증: 드롭다운 이동, swap, 아코디언 유지, 셔플

## 변경 파일
- `generate_challenge.py` — `main(total_problems)` 파라미터화, 데이터 스케일링, STEP 범위 완화 (STEP1_MAX 150→400, STEP2_MAX 100→300), Type I/J 답 dedup 제거
- `init_db.py` — `init_database()` 시그니처 변경, `compute_group_sizes` 헬퍼, `has_app_context()` 재사용
- `app.py` — `/admin/init*` 라우트 5개 + 헬퍼
- `templates/admin_init.html` — 3단계 마법사 (신규) + swap/아코디언 유지 수정
- `templates/admin_dashboard.html` — 초기화 마법사 링크 + 산출물 3버튼 + 2개 모달

## Test plan
- [ ] 관리자 로그인 후 `/admin/dashboard`에서 firstPlayer / roster / challenge_data / 초기화 마법사 버튼 확인
- [ ] firstPlayer.txt 버튼 → 모달 인라인 표시 + 복사 동작
- [ ] groupRoster.txt 버튼 → "정답 포함" 경고 + 모달 인라인 표시
- [ ] `/admin/init`에서 N·G 입력 시 조당 인원 실시간 계산
- [ ] CSV 붙여넣기 (헤더 있음/없음, 탭/쉼표)
- [ ] 중복 knox_id 에러 표시
- [ ] 2단계에서 ▲▼ 이동, 드롭다운 조 이동(swap), 셔플
- [ ] 아코디언 펼친 상태에서 이동·셔플 시 펼침 유지
- [ ] 3단계 INIT 타이핑 시 버튼 활성화
- [ ] N > 130일 때 regen 자동 체크 + 해제 불가
- [ ] 진행 중 주자 있을 때 force 미체크 → 에러 / 체크 후 성공
- [ ] 결과 화면에서 firstPlayer.txt 복사·다운로드
- [ ] CLI `python init_db.py` 정상 동작 (하위호환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)