### PR TITLE
초기화 마법사에 난이도 선택 (Easy/Medium)

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ SETTINGS_PATH = os.path.join(os.path.dirname(__file__), 'settings.json')
 DEFAULT_SETTINGS = {
     'show_individual_ranking': True,
     'challenge_opened': False,   # 참가자에게 공개 여부. 관리자가 명시적으로 열어야 함.
+    'difficulty': 'medium',      # easy | medium (hard는 차후)
 }
 
 
@@ -521,6 +522,7 @@ def admin_dashboard():
     total_runners = sum(r['total'] for r in rankings)
     challenge_opened = _is_challenge_open()
     initialized = Runner.query.count() > 0
+    settings = _read_settings()
 
     return render_template('admin_dashboard.html',
                            groups=groups,
@@ -529,7 +531,8 @@ def admin_dashboard():
                            total_completed=total_completed,
                            total_runners=total_runners,
                            challenge_opened=challenge_opened,
-                           initialized=initialized)
+                           initialized=initialized,
+                           difficulty=settings.get('difficulty', 'medium'))
 
 
 @app.route('/admin/skip/<int:runner_id>', methods=['POST'])
@@ -992,6 +995,12 @@ def admin_init_commit():
 
     # 운영 옵션 (리더보드 개인 랭킹 공개 여부 등)
     show_individual = bool(data.get('show_individual_ranking', True))
+    difficulty = data.get('difficulty', 'medium')
+    if difficulty not in ('easy', 'medium'):
+        return jsonify({
+            'ok': False, 'error_code': 'VALIDATION',
+            'message': f'unknown difficulty: {difficulty!r}'
+        }), 400
 
     # 6) init_database 실행 — 세션/엔진을 먼저 닫아야 Windows에서 DB 파일 삭제 가능
     db.session.remove()
@@ -1004,6 +1013,7 @@ def admin_init_commit():
             group_sizes=group_sizes,
             ordered_participants=norm_ordered,
             regen_challenge_data=regen,
+            difficulty=difficulty,
         )
     except Exception as e:
         return jsonify({
@@ -1018,6 +1028,7 @@ def admin_init_commit():
         _write_settings({
             'show_individual_ranking': show_individual,
             'challenge_opened': False,
+            'difficulty': difficulty,
         })
     except OSError:
         pass  # 파일 쓰기 실패해도 초기화 자체는 성공으로 간주

--- a/generate_challenge.py
+++ b/generate_challenge.py
@@ -541,7 +541,7 @@ def generate_type_b_problems(json_records, log_entries, n=PROBLEMS_PER_TYPE):
     combos = []
     for dept in DEPARTMENTS:
         for status in STATUSES:
-            for level in ["ERROR", "WARN", "CRITICAL"]:
+            for level in LOG_LEVELS:  # 5 levels — Easy 모드 N=500까지 풀 확보
                 combos.append((dept, status, level))
     random.shuffle(combos)
 
@@ -661,7 +661,6 @@ def generate_type_c_problems(csv_rows, n=PROBLEMS_PER_TYPE):
 def generate_type_d_problems(code_data, n=PROBLEMS_PER_TYPE):
     """Type D: 코드 블록 분석"""
     problems = []
-    used_answers = set()
 
     combos = []
     for lang in LANGUAGES:
@@ -694,10 +693,6 @@ def generate_type_d_problems(code_data, n=PROBLEMS_PER_TYPE):
         result = keyword_line_count * len(unique_funcs)
         answer = f"{result}"
 
-        if answer in used_answers:
-            continue
-        used_answers.add(answer)
-
         text = (f"challenge_data.dat 파일에서 코드 블록을 분석하세요:\n"
                 f"- 대상: 언어 태그가 [{lang}]인 모든 CODE_BLOCK\n"
                 f"- 분석 1: 해당 블록들의 코드 라인 중 \"{keyword}\"를 포함하는 라인의 수 (A)\n"
@@ -722,19 +717,22 @@ def generate_type_e_problems(registry_entries, n=PROBLEMS_PER_TYPE):
     problems = []
     used_answers = set()
 
+    # combo: (tag, min_metric, sort_field, return_attr) — min_metric으로 조합 확장
     combos = []
     for tag in TAGS:
-        for sort_field in ["metric", "priority"]:
-            for return_attr in ["ref", "metric", "entry_id"]:
-                combos.append((tag, sort_field, return_attr))
+        for min_metric in [0, 100, 250, 500]:
+            for sort_field in ["metric", "priority"]:
+                for return_attr in ["ref", "metric", "entry_id"]:
+                    combos.append((tag, min_metric, sort_field, return_attr))
     random.shuffle(combos)
 
     for combo in combos:
         if len(problems) >= n:
             break
-        tag, sort_field, return_attr = combo
+        tag, min_metric, sort_field, return_attr = combo
 
-        filtered = [e for e in registry_entries if e["tag"] == tag]
+        filtered = [e for e in registry_entries
+                    if e["tag"] == tag and e["metric"] >= min_metric]
         if len(filtered) < 5:
             continue
 
@@ -743,11 +741,10 @@ def generate_type_e_problems(registry_entries, n=PROBLEMS_PER_TYPE):
         else:
             filtered.sort(key=lambda x: x["priority"])
 
-        # nth item (5~len 사이에서 랜덤)
         max_n = min(len(filtered), 30)
         nth = random.randint(5, max_n)
 
-        item = filtered[nth - 1]  # 1-indexed
+        item = filtered[nth - 1]
         answer = str(item[return_attr])
 
         if answer in used_answers:
@@ -756,9 +753,10 @@ def generate_type_e_problems(registry_entries, n=PROBLEMS_PER_TYPE):
 
         sort_kr = "metric (오름차순, 숫자)" if sort_field == "metric" else "priority (오름차순, 알파벳)"
         attr_kr = {"ref": "ref(직원 ID)", "metric": "metric 값", "entry_id": "entry_id"}[return_attr]
+        metric_filter_kr = "" if min_metric == 0 else f"이고 metric >= {min_metric}"
 
         text = (f"challenge_data.dat 파일에서 레지스트리 항목을 분석하세요:\n"
-                f"- 대상: 모든 REGISTRY 섹션에서 tag={tag}인 항목을 수집\n"
+                f"- 대상: 모든 REGISTRY 섹션에서 tag={tag}{metric_filter_kr} 인 항목을 수집\n"
                 f"- 정렬: {sort_kr}\n"
                 f"- 결과: 정렬 후 {nth}번째 항목의 {attr_kr}를 제출하세요\n"
                 f"(총 {len(filtered)}개 항목이 매칭되어야 합니다)\n"
@@ -769,8 +767,8 @@ def generate_type_e_problems(registry_entries, n=PROBLEMS_PER_TYPE):
             ptype="E",
             text=text,
             answer=answer,
-            params={"tag": tag, "sort_field": sort_field, "nth": nth,
-                    "return_attr": return_attr, "total": len(filtered)}
+            params={"tag": tag, "min_metric": min_metric, "sort_field": sort_field,
+                    "nth": nth, "return_attr": return_attr, "total": len(filtered)}
         ))
 
     return problems
@@ -995,11 +993,21 @@ def _scaled_data_sizes(total_problems: int) -> dict:
     }
 
 
-def _build_pools(total_problems: int):
-    """유형별 풀을 생성해 (pools, data_bundle) 반환. 내부에서 seed 재설정."""
+DIFFICULTY_LEVELS = ('easy', 'medium')  # 'hard'는 이번 범위 밖
+
+
+def _build_pools(total_problems: int, difficulty: str = 'medium'):
+    """유형별 풀을 생성해 (pools, data_bundle) 반환. 내부에서 seed 재설정.
+
+    difficulty:
+      - 'easy'  : Type A/C/D/E (1-hop, 4유형)
+      - 'medium': Type F/G/H/I/J (2-hop, 5유형) — 현재 2차 기본
+    """
+    if difficulty not in DIFFICULTY_LEVELS:
+        raise ValueError(f"unknown difficulty: {difficulty!r} (allowed: {DIFFICULTY_LEVELS})")
+
     random.seed(SEED)
     sizes = _scaled_data_sizes(total_problems)
-    per_type = math.ceil(total_problems / NUM_PROBLEM_TYPES)
 
     employees = generate_employees(sizes["n_employees"])
     log_sections, log_entries = generate_log_sections(
@@ -1018,13 +1026,24 @@ def _build_pools(total_problems: int):
     prose_sections = generate_prose_blocks()
     meta_sections = generate_metadata_dumps()
 
-    pools = [
-        generate_type_f_problems(json_records, log_entries, n=per_type),
-        generate_type_g_problems(json_records, registry_entries, n=per_type),
-        generate_type_h_problems(registry_entries, json_records, n=per_type),
-        generate_type_i_problems(log_entries, json_records, n=per_type),
-        generate_type_j_problems(log_entries, registry_entries, n=per_type),
-    ]
+    per_type = math.ceil(total_problems / NUM_PROBLEM_TYPES)
+    if difficulty == 'easy':
+        # 1차와 동일 구성: A/B/C/D/E (B만 2-hop, 나머지는 1-hop)
+        pools = [
+            generate_type_a_problems(log_entries, n=per_type),
+            generate_type_b_problems(json_records, log_entries, n=per_type),
+            generate_type_c_problems(csv_rows, n=per_type),
+            generate_type_d_problems(code_data, n=per_type),
+            generate_type_e_problems(registry_entries, n=per_type),
+        ]
+    else:  # medium — 2차 균일 2-hop
+        pools = [
+            generate_type_f_problems(json_records, log_entries, n=per_type),
+            generate_type_g_problems(json_records, registry_entries, n=per_type),
+            generate_type_h_problems(registry_entries, json_records, n=per_type),
+            generate_type_i_problems(log_entries, json_records, n=per_type),
+            generate_type_j_problems(log_entries, registry_entries, n=per_type),
+        ]
 
     bundle = {
         "all_sections": (log_sections + json_sections + csv_sections +
@@ -1047,11 +1066,12 @@ def _build_pools(total_problems: int):
 
 
 def _assign_problems_from_pools(pools, total_problems):
-    """5개 풀을 순환하며 total_problems개를 배정. 부족하면 다른 풀에서 보충."""
-    pool_indices = [0] * NUM_PROBLEM_TYPES
+    """가변 개수 풀을 순환하며 total_problems개 배정. 부족하면 다른 풀에서 보충."""
+    n_pools = len(pools)
+    pool_indices = [0] * n_pools
     assigned = []
     for i in range(total_problems):
-        type_idx = i % NUM_PROBLEM_TYPES
+        type_idx = i % n_pools
         pool = pools[type_idx]
         if pool_indices[type_idx] < len(pool):
             p = pool[pool_indices[type_idx]]
@@ -1059,7 +1079,7 @@ def _assign_problems_from_pools(pools, total_problems):
             assigned.append(p)
             pool_indices[type_idx] += 1
         else:
-            for alt in range(NUM_PROBLEM_TYPES):
+            for alt in range(n_pools):
                 if pool_indices[alt] < len(pools[alt]):
                     p = pools[alt][pool_indices[alt]]
                     p.pid = i + 1
@@ -1286,81 +1306,52 @@ def create_excel(all_problems, filename="challenge_admin.xlsx"):
 # 메인
 # ============================================================
 def main(total_problems: int = DEFAULT_TOTAL_PROBLEMS,
+         difficulty: str = 'medium',
          output_path: str = "challenge_data.dat",
          excel_path: str = "challenge_admin.xlsx"):
+    if difficulty not in DIFFICULTY_LEVELS:
+        raise ValueError(f"unknown difficulty: {difficulty!r}")
+
     print("=" * 60)
-    print(f"코딩 에이전트 릴레이 설치 챌린지 - 문제 생성기 (N={total_problems})")
+    print(f"코딩 에이전트 릴레이 설치 챌린지 (N={total_problems}, difficulty={difficulty})")
     print("=" * 60)
 
-    sizes = _scaled_data_sizes(total_problems)
-    per_type = math.ceil(total_problems / NUM_PROBLEM_TYPES)
-
-    # 1. 데이터 생성
-    random.seed(SEED)
-    print(f"\n[1/6] 직원 풀 생성 (n={sizes['n_employees']})...")
-    employees = generate_employees(sizes["n_employees"])
-
-    print("[2/6] 섹션 생성...")
-    log_sections, log_entries = generate_log_sections(
-        employees,
-        n_sections=sizes["n_log_sections"],
-        lines_per_section=sizes["log_lines_per_section"],
-    )
-    json_sections, json_records = generate_json_blocks(employees)
-    csv_sections, csv_rows = generate_csv_tables()
-    code_sections, code_data = generate_code_blocks()
-    registry_sections, registry_entries = generate_registry_sections(
-        n_sections=sizes["n_registry_sections"],
-        entries_per_section=sizes["registry_entries_per_section"],
-        emp_count=len(employees),
-    )
-    prose_sections = generate_prose_blocks()
-    meta_sections = generate_metadata_dumps()
-
-    all_sections = (log_sections + json_sections + csv_sections +
-                    code_sections + registry_sections + prose_sections + meta_sections)
+    # 1~3. 섹션 데이터 생성 + challenge_data.dat 작성 + 풀 빌드
+    pools, bundle = _build_pools(total_problems, difficulty=difficulty)
+    all_sections = bundle["all_sections"]
 
     print(f"  총 {len(all_sections)}개 섹션 생성")
-    print(f"  - 로그: {len(log_sections)} ({len(log_entries)} entries)")
-    print(f"  - JSON: {len(json_sections)} ({len(json_records)} records)")
-    print(f"  - CSV: {len(csv_sections)} ({len(csv_rows)} rows)")
-    print(f"  - 코드: {len(code_sections)} ({len(code_data)} blocks)")
-    print(f"  - 레지스트리: {len(registry_sections)} ({len(registry_entries)} entries)")
-    print(f"  - 산문: {len(prose_sections)} blocks")
-    print(f"  - 메타데이터: {len(meta_sections)} dumps")
+    print(f"  - 로그: {len(bundle['log_sections'])} ({len(bundle['log_entries'])} entries)")
+    print(f"  - JSON: {len(bundle['json_sections'])} ({len(bundle['json_records'])} records)")
+    print(f"  - CSV: {len(bundle['csv_sections'])} ({len(bundle['csv_rows'])} rows)")
+    print(f"  - 코드: {len(bundle['code_sections'])} ({len(bundle['code_data'])} blocks)")
+    print(f"  - 레지스트리: {len(bundle['registry_sections'])} ({len(bundle['registry_entries'])} entries)")
+    print(f"  - 산문: {len(bundle['prose_sections'])} blocks")
+    print(f"  - 메타데이터: {len(bundle['meta_sections'])} dumps")
 
-    # 2. 파일 조립
-    print(f"\n[3/6] {output_path} 생성...")
+    # 파일 조립
+    print(f"\n  → {output_path} 작성")
     file_content = assemble_challenge_file(all_sections)
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(file_content)
     line_count = file_content.count("\n") + 1
     file_size = len(file_content.encode("utf-8"))
-    print(f"  -> {line_count:,} 줄, {file_size:,} bytes ({file_size / 1024:.1f} KB)")
+    print(f"     {line_count:,} 줄, {file_size:,} bytes ({file_size / 1024:.1f} KB)")
 
-    # 3. 문제 생성 (모든 유형 2-hop, 유형별 per_type개씩 요청)
-    print(f"\n[4/6] {total_problems}개 2-hop 문제 생성 (유형별 {per_type}개 시도)...")
-    problems_f = generate_type_f_problems(json_records, log_entries, n=per_type)
-    problems_g = generate_type_g_problems(json_records, registry_entries, n=per_type)
-    problems_h = generate_type_h_problems(registry_entries, json_records, n=per_type)
-    problems_i = generate_type_i_problems(log_entries, json_records, n=per_type)
-    problems_j = generate_type_j_problems(log_entries, registry_entries, n=per_type)
+    # 풀 yield 출력
+    pool_names = (['A','B','C','D','E'] if difficulty == 'easy'
+                  else ['F','G','H','I','J'])
+    print(f"\n  유형별 생성 ({difficulty}):")
+    for name, pool in zip(pool_names, pools):
+        print(f"    Type {name}: {len(pool)}개")
 
-    print(f"  Type F (JSON→LOG 합계): {len(problems_f)}개")
-    print(f"  Type G (JSON→REG 합계): {len(problems_g)}개")
-    print(f"  Type H (REG→JSON 합계): {len(problems_h)}개")
-    print(f"  Type I (LOG→JSON 카운트): {len(problems_i)}개")
-    print(f"  Type J (LOG→REG 카운트): {len(problems_j)}개")
-
-    all_pools = [problems_f, problems_g, problems_h, problems_i, problems_j]
-    total_generated = sum(len(p) for p in all_pools)
+    total_generated = sum(len(p) for p in pools)
     if total_generated < total_problems:
         raise RuntimeError(
-            f"문제 생성 부족: 요청 {total_problems}개, 생성 {total_generated}개. "
-            "섹션 풀 크기를 키우거나 난이도 제약(STEP1/STEP2 MIN/MAX)을 완화하세요."
+            f"문제 생성 부족: 요청 {total_problems}개, 생성 {total_generated}개."
         )
 
-    all_problems = _assign_problems_from_pools(all_pools, total_problems)
+    all_problems = _assign_problems_from_pools(pools, total_problems)
 
     # 답 중복 검사
     answers = [p.answer for p in all_problems]
@@ -1384,9 +1375,10 @@ def main(total_problems: int = DEFAULT_TOTAL_PROBLEMS,
     print("=" * 60)
 
 
-def get_all_problems(total_problems: int = DEFAULT_TOTAL_PROBLEMS):
+def get_all_problems(total_problems: int = DEFAULT_TOTAL_PROBLEMS,
+                     difficulty: str = 'medium'):
     """외부에서 호출하여 total_problems개 문제 목록을 반환."""
-    pools, _bundle = _build_pools(total_problems)
+    pools, _bundle = _build_pools(total_problems, difficulty=difficulty)
     total_generated = sum(len(p) for p in pools)
     if total_generated < total_problems:
         raise RuntimeError(
@@ -1398,10 +1390,13 @@ def get_all_problems(total_problems: int = DEFAULT_TOTAL_PROBLEMS):
 if __name__ == "__main__":
     import sys
     n = DEFAULT_TOTAL_PROBLEMS
+    diff = 'medium'
     if len(sys.argv) > 1:
         try:
             n = int(sys.argv[1])
         except ValueError:
-            print(f"사용법: python generate_challenge.py [total_problems]")
+            print(f"사용법: python generate_challenge.py [total_problems] [easy|medium]")
             sys.exit(1)
-    main(total_problems=n)
+    if len(sys.argv) > 2:
+        diff = sys.argv[2]
+    main(total_problems=n, difficulty=diff)

--- a/init_db.py
+++ b/init_db.py
@@ -104,6 +104,7 @@ def init_database(
     group_sizes: list[int] | None = None,
     ordered_participants: list[dict] | None = None,
     regen_challenge_data: bool = False,
+    difficulty: str = 'medium',
 ) -> dict:
     """
     DB를 삭제 후 재생성하고 참가자·조·문제를 배정한다.
@@ -142,9 +143,10 @@ def init_database(
 
     # 문제 풀 재생성 (필요 시)
     if regen_challenge_data:
-        print(f"challenge_data.dat 재생성 (N={total})...")
+        print(f"challenge_data.dat 재생성 (N={total}, difficulty={difficulty})...")
         generate_main(
             total_problems=total,
+            difficulty=difficulty,
             output_path=os.path.join(BASE_DIR, "challenge_data.dat"),
             excel_path=os.path.join(BASE_DIR, "challenge_admin.xlsx"),
         )
@@ -176,8 +178,8 @@ def init_database(
 
         try:
             # 1. 문제 로드 (total개)
-            print(f"{total}개 문제 로드 중...")
-            problems = get_all_problems(total_problems=total)
+            print(f"{total}개 문제 로드 중 (difficulty={difficulty})...")
+            problems = get_all_problems(total_problems=total, difficulty=difficulty)
             if len(problems) < total:
                 raise RuntimeError(
                     f"문제 부족: 요청 {total}개, 생성 {len(problems)}개. "

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -19,6 +19,12 @@
             🔒 비공개 (준비 중)
         </span>
         {% endif %}
+        {% if initialized %}
+        <span class="badge bg-info" style="font-size: 0.85rem; padding: 0.5rem 0.75rem; color: #000;"
+              title="현재 챌린지 난이도">
+            난이도: {{ 'Easy (1-hop)' if difficulty == 'easy' else 'Medium (2-hop)' }}
+        </span>
+        {% endif %}
     </div>
     <div>
         <span style="color: var(--text-secondary); font-size: 0.85rem;" id="auto-refresh-status">5초마다 자동 갱신</span>

--- a/templates/admin_init.html
+++ b/templates/admin_init.html
@@ -56,23 +56,34 @@
       <div class="card-body">
 
         <div class="row g-3">
-          <div class="col-md-4">
+          <div class="col-md-3">
             <label class="form-label" style="font-weight: 600;">전체 인원수 (N)</label>
             <input type="number" class="form-control" id="input-n"
                    value="{{ default_n }}" min="{{ n_min }}" max="{{ n_max }}">
             <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
-              범위: {{ n_min }} ~ {{ n_max }}
+              {{ n_min }} ~ {{ n_max }}
             </div>
           </div>
-          <div class="col-md-4">
+          <div class="col-md-3">
             <label class="form-label" style="font-weight: 600;">조 수 (G)</label>
             <input type="number" class="form-control" id="input-g"
                    value="{{ default_g }}" min="{{ g_min }}" max="{{ g_max }}">
             <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
-              범위: {{ g_min }} ~ {{ g_max }}, G ≤ N
+              {{ g_min }} ~ {{ g_max }}, G ≤ N
             </div>
           </div>
-          <div class="col-md-4">
+          <div class="col-md-3">
+            <label class="form-label" style="font-weight: 600;">난이도</label>
+            <select class="form-select" id="input-difficulty">
+              <option value="easy">Easy (1차 수준, 1-hop 위주)</option>
+              <option value="medium" selected>Medium (2차 수준, 2-hop 균일)</option>
+              <option value="hard" disabled>Hard (3-hop, 차후 지원)</option>
+            </select>
+            <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
+              Easy: 입문/타 부서 · Medium: 표준
+            </div>
+          </div>
+          <div class="col-md-3">
             <label class="form-label" style="font-weight: 600;">현재 문제 풀</label>
             <div class="form-control-plaintext" id="pool-info">
               {{ problem_pool_size }}개
@@ -637,6 +648,7 @@
       regen_challenge_data: el('opt-regen').checked,
       force: el('opt-force').checked,
       show_individual_ranking: el('opt-show-individual').checked,
+      difficulty: el('input-difficulty').value,
       confirm: el('confirm-input').value,
     };
 


### PR DESCRIPTION
Closes #24

## 요약
초기화 마법사 1단계에 난이도 셀렉트박스 추가. 부서·대상에 맞춰 챌린지 난이도 조정 가능.

| 레벨 | 구성 | 대상 |
|---|---|---|
| **Easy** | 1차 동일 (Type A/B/C/D/E) | 입문자·타 부서 |
| **Medium** | 현재 2차 (Type F/G/H/I/J, 2-hop 균일) | AI팀 표준 |
| Hard | (UI에서 disabled, 차후) | — |

## 구현
- `generate_challenge.main(total, difficulty=...)` 파라미터화
- `get_all_problems(total, difficulty=...)` 파라미터화
- `init_database(..., difficulty=...)` 파라미터화
- `_build_pools` 가 difficulty 분기로 풀 선택
- `app.admin_init_commit` 가 difficulty 받아 init·settings.json 저장
- `templates/admin_init.html` 1단계: 셀렉트박스
- `templates/admin_dashboard.html`: 현재 난이도 뱃지

## 풀 yield 확장 (대규모 N 지원)
- Type B: LOG_LEVELS 전체 사용 (3→5 레벨) → 96→160 combo
- Type D: 답 dedup 제거 (round 2의 I/J 패턴) → yield 향상
- Type E: `min_metric` 필터 차원 추가 → 48→192 combo

## 동작 검증
- N=130 / 250 / 350 Easy: 정확히 N개 생성 ✓
- N=500 Easy: 475/500 (Type D 75 한계) — 실용 운영 영향 적음
- N=130 / 500 Medium: 정확히 N개 ✓
- difficulty 'hard' 요청: 400 VALIDATION ✓
- Easy/Medium 토글 후 DB 유형 일치 확인 (A/B/C/D/E ↔ F/G/H/I/J)

## Test plan
- [ ] `/admin/init` 1단계: 난이도 셀렉트박스 노출, Hard disabled
- [ ] Easy로 초기화 → 대시보드 뱃지 "난이도: Easy (1-hop)"
- [ ] Medium으로 초기화 → 뱃지 "난이도: Medium (2-hop)"
- [ ] 참가자 화면에서 문제 텍스트가 해당 난이도에 맞게 표시 (1-hop vs 2-hop)
- [ ] CLI `python generate_challenge.py 130 easy` 동작
- [ ] CLI `python init_db.py` 하위호환 (medium 기본)

🤖 Generated with [Claude Code](https://claude.com/claude-code)