### PR TITLE
미루기 꼼수 차단 (새 문제 교체 + 패널티)

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from functools import wraps
 
 from flask import (Flask, render_template, request, redirect, url_for,
                    session, flash, send_file, jsonify, abort, make_response)
-from models import db, Group, Runner, AttemptLog
+from models import db, Group, Runner, AttemptLog, SpareProblem
 import config
 
 
@@ -24,6 +24,8 @@ DEFAULT_SETTINGS = {
     'show_individual_ranking': True,
     'challenge_opened': False,   # 참가자에게 공개 여부. 관리자가 명시적으로 열어야 함.
     'difficulty': 'medium',      # easy | medium (hard는 차후)
+    'defer_penalty_seconds': 60, # 미루기 1회당 개인 랭킹에 더해지는 패널티 (초)
+    'buffer_ratio': 0.3,         # 스페어 풀 비율 (전체 인원 대비)
 }
 
 
@@ -40,6 +42,20 @@ def _write_settings(data: dict) -> None:
     merged = {**DEFAULT_SETTINGS, **_read_settings(), **data}
     with open(SETTINGS_PATH, 'w', encoding='utf-8') as f:
         json.dump(merged, f, ensure_ascii=False, indent=2)
+
+
+def _swap_with_spare_problem(runner) -> bool:
+    """미사용 스페어 문제를 1건 가져와 runner의 문제를 교체.
+    성공하면 True, 스페어 풀이 비어있으면 False (동일 문제 유지)."""
+    spare = SpareProblem.query.filter_by(consumed_at=None).order_by(SpareProblem.id).first()
+    if spare is None:
+        return False
+    runner.problem_text = spare.problem_text
+    runner.problem_type = spare.problem_type
+    runner.correct_answer = spare.correct_answer
+    spare.consumed_at = datetime.utcnow()
+    spare.consumed_by_runner_id = runner.id
+    return True
 
 
 def _is_challenge_open() -> bool:
@@ -370,6 +386,11 @@ def defer():
     runner.started_at = None
     runner.attempts = 0
     runner.reason = reason or None
+    runner.deferred_count = (runner.deferred_count or 0) + 1
+    runner.submitted_answer = None
+
+    # 새 문제로 교체 (스페어 풀에서 1건). 풀 비어있으면 동일 문제 유지.
+    swapped = _swap_with_spare_problem(runner)
 
     # 당겨진 순서에 있는 waiting 주자 활성화
     next_runner = Runner.query.filter_by(
@@ -383,7 +404,10 @@ def defer():
 
     db.session.commit()
     session.pop('runner_id', None)
-    flash('차례를 맨 뒤로 미뤘습니다. 다음 주자가 활성화됩니다.', 'info')
+    if swapped:
+        flash('차례를 맨 뒤로 미뤘습니다. 다음 차례에는 새 문제가 출제됩니다.', 'info')
+    else:
+        flash('차례를 맨 뒤로 미뤘습니다. (스페어 풀 부족: 동일 문제 유지)', 'warning')
     return redirect(url_for('index'))
 
 
@@ -416,18 +440,27 @@ def success():
                            is_group_finished=is_group_finished)
 
 
-def get_individual_rankings(limit=20):
-    """개인 경과시간 랭킹 — status='completed' 주자만, 경과시간 오름차순."""
+def get_individual_rankings(limit=20, defer_penalty_seconds=60):
+    """개인 경과시간 랭킹 — status='completed' 주자만, 보정 경과시간 오름차순.
+
+    보정 경과시간 = (completed_at - started_at) + deferred_count * defer_penalty_seconds
+    """
     runners = Runner.query.filter_by(status='completed')\
         .filter(Runner.started_at.isnot(None))\
         .filter(Runner.completed_at.isnot(None)).all()
     items = []
     for r in runners:
-        elapsed = r.completed_at - r.started_at
+        raw = r.completed_at - r.started_at
+        defers = r.deferred_count or 0
+        penalty = timedelta(seconds=defers * defer_penalty_seconds)
+        adjusted = raw + penalty
         items.append({
             'runner': r,
-            'elapsed': elapsed,
-            'elapsed_seconds': int(elapsed.total_seconds()),
+            'elapsed': adjusted,                 # 보정값 (랭킹 기준)
+            'elapsed_seconds': int(adjusted.total_seconds()),
+            'raw_elapsed': raw,
+            'defers': defers,
+            'penalty': penalty,
         })
     items.sort(key=lambda x: x['elapsed_seconds'])
     for i, it in enumerate(items[:limit]):
@@ -441,11 +474,14 @@ def leaderboard():
     rankings = get_group_rankings()
     settings = _read_settings()
     show_individual = settings.get('show_individual_ranking', True)
-    individuals = get_individual_rankings(limit=10) if show_individual else []
+    penalty_sec = int(settings.get('defer_penalty_seconds', 60))
+    individuals = (get_individual_rankings(limit=10, defer_penalty_seconds=penalty_sec)
+                   if show_individual else [])
     return render_template('leaderboard.html',
                            rankings=rankings,
                            individuals=individuals,
-                           show_individual=show_individual)
+                           show_individual=show_individual,
+                           defer_penalty_seconds=penalty_sec)
 
 
 @app.route('/guide')
@@ -523,6 +559,9 @@ def admin_dashboard():
     challenge_opened = _is_challenge_open()
     initialized = Runner.query.count() > 0
     settings = _read_settings()
+    spare_total = SpareProblem.query.count()
+    spare_used = SpareProblem.query.filter(SpareProblem.consumed_at.isnot(None)).count()
+    spare_remaining = spare_total - spare_used
 
     return render_template('admin_dashboard.html',
                            groups=groups,
@@ -532,7 +571,11 @@ def admin_dashboard():
                            total_runners=total_runners,
                            challenge_opened=challenge_opened,
                            initialized=initialized,
-                           difficulty=settings.get('difficulty', 'medium'))
+                           difficulty=settings.get('difficulty', 'medium'),
+                           defer_penalty_seconds=int(settings.get('defer_penalty_seconds', 60)),
+                           spare_total=spare_total,
+                           spare_used=spare_used,
+                           spare_remaining=spare_remaining)
 
 
 @app.route('/admin/skip/<int:runner_id>', methods=['POST'])
@@ -602,12 +645,15 @@ def admin_defer(runner_id):
     for r in later_runners:
         r.run_order -= 1
 
-    # 해당 주자를 맨 뒤로 (시작 시간 초기화)
+    # 해당 주자를 맨 뒤로 (시작 시간 초기화 + 미루기 카운트 +1 + 새 문제 교체)
     runner.run_order = max_order
     runner.status = 'waiting'
     runner.password = ''
     runner.started_at = None
     runner.attempts = 0
+    runner.deferred_count = (runner.deferred_count or 0) + 1
+    runner.submitted_answer = None
+    swapped = _swap_with_spare_problem(runner)
 
     # active였으면 다음 주자(당겨진 순서) 활성화
     if was_active:
@@ -622,8 +668,9 @@ def admin_defer(runner_id):
 
     db.session.commit()
     if _is_ajax():
-        return jsonify({'ok': True})
-    flash(f'{runner.name}을(를) 맨 뒤로 미뤘습니다. (새 순서: {max_order}번째)', 'info')
+        return jsonify({'ok': True, 'swapped': swapped})
+    msg_suffix = '' if swapped else ' (스페어 풀 부족: 동일 문제 유지)'
+    flash(f'{runner.name}을(를) 맨 뒤로 미뤘습니다. (새 순서: {max_order}번째){msg_suffix}', 'info')
     return redirect(url_for('admin_dashboard'))
 
 
@@ -1001,6 +1048,18 @@ def admin_init_commit():
             'ok': False, 'error_code': 'VALIDATION',
             'message': f'unknown difficulty: {difficulty!r}'
         }), 400
+    try:
+        defer_penalty_seconds = int(data.get('defer_penalty_seconds', 60))
+        buffer_ratio = float(data.get('buffer_ratio', 0.3))
+    except (TypeError, ValueError):
+        return jsonify({'ok': False, 'error_code': 'VALIDATION',
+                        'message': 'defer_penalty_seconds/buffer_ratio 형식 오류'}), 400
+    if not (0 <= defer_penalty_seconds <= 600):
+        return jsonify({'ok': False, 'error_code': 'VALIDATION',
+                        'message': '미루기 패널티는 0~600초 범위'}), 400
+    if not (0.0 <= buffer_ratio <= 0.5):
+        return jsonify({'ok': False, 'error_code': 'VALIDATION',
+                        'message': '스페어 풀 비율은 0~50% 범위'}), 400
 
     # 6) init_database 실행 — 세션/엔진을 먼저 닫아야 Windows에서 DB 파일 삭제 가능
     db.session.remove()
@@ -1014,6 +1073,7 @@ def admin_init_commit():
             ordered_participants=norm_ordered,
             regen_challenge_data=regen,
             difficulty=difficulty,
+            buffer_ratio=buffer_ratio,
         )
     except Exception as e:
         return jsonify({
@@ -1029,6 +1089,8 @@ def admin_init_commit():
             'show_individual_ranking': show_individual,
             'challenge_opened': False,
             'difficulty': difficulty,
+            'defer_penalty_seconds': defer_penalty_seconds,
+            'buffer_ratio': buffer_ratio,
         })
     except OSError:
         pass  # 파일 쓰기 실패해도 초기화 자체는 성공으로 간주
@@ -1040,6 +1102,7 @@ def admin_init_commit():
             'groups': result['groups'],
             'runners': result['runners'],
             'problems': result['runners'],
+            'spare_count': result.get('spare_count', 0),
         },
     })
 

--- a/init_db.py
+++ b/init_db.py
@@ -105,6 +105,7 @@ def init_database(
     ordered_participants: list[dict] | None = None,
     regen_challenge_data: bool = False,
     difficulty: str = 'medium',
+    buffer_ratio: float = 0.3,
 ) -> dict:
     """
     DB를 삭제 후 재생성하고 참가자·조·문제를 배정한다.
@@ -120,8 +121,9 @@ def init_database(
     }
     """
     sys.path.insert(0, BASE_DIR)
-    from models import db, Group, Runner
+    from models import db, Group, Runner, SpareProblem
     from flask import current_app, has_app_context
+    import math as _math
 
     # ordered_participants가 주어지면 N도 거기서 도출
     if ordered_participants is not None:
@@ -141,11 +143,15 @@ def init_database(
                 f"group_sizes 합({sum(group_sizes)}) != total({total})"
             )
 
+    # 스페어 풀: total + buffer 만큼 문제 생성
+    buffer_count = max(0, _math.ceil(total * float(buffer_ratio)))
+    grand_total = total + buffer_count
+
     # 문제 풀 재생성 (필요 시)
     if regen_challenge_data:
-        print(f"challenge_data.dat 재생성 (N={total}, difficulty={difficulty})...")
+        print(f"challenge_data.dat 재생성 (N={grand_total} = 본 {total} + 스페어 {buffer_count}, difficulty={difficulty})...")
         generate_main(
-            total_problems=total,
+            total_problems=grand_total,
             difficulty=difficulty,
             output_path=os.path.join(BASE_DIR, "challenge_data.dat"),
             excel_path=os.path.join(BASE_DIR, "challenge_admin.xlsx"),
@@ -177,15 +183,17 @@ def init_database(
         print("DB 테이블 생성 완료")
 
         try:
-            # 1. 문제 로드 (total개)
-            print(f"{total}개 문제 로드 중 (difficulty={difficulty})...")
-            problems = get_all_problems(total_problems=total, difficulty=difficulty)
-            if len(problems) < total:
+            # 1. 문제 로드 (총 grand_total개 = 본 + 스페어)
+            print(f"{grand_total}개 문제 로드 중 (본 {total} + 스페어 {buffer_count}, difficulty={difficulty})...")
+            problems = get_all_problems(total_problems=grand_total, difficulty=difficulty)
+            if len(problems) < grand_total:
                 raise RuntimeError(
-                    f"문제 부족: 요청 {total}개, 생성 {len(problems)}개. "
-                    "regen_challenge_data=True 로 재생성하세요."
+                    f"문제 부족: 요청 {grand_total}개, 생성 {len(problems)}개. "
+                    "regen_challenge_data=True 로 재생성하거나 buffer_ratio를 줄이세요."
                 )
-            print(f"  {len(problems)}개 문제 준비 완료")
+            main_problems = problems[:total]
+            spare_problems = problems[total:]
+            print(f"  본 {len(main_problems)}개 + 스페어 {len(spare_problems)}개 준비 완료")
 
             # 2. 참가자 순서 확정
             if ordered_participants is not None:
@@ -247,7 +255,7 @@ def init_database(
                 g_id = entry['group']
                 order = entry['order']
                 problem_idx = group_offsets[g_id - 1] + (order - 1)
-                problem = problems[problem_idx]
+                problem = main_problems[problem_idx]
 
                 if order == 1:
                     password = generate_password()
@@ -279,8 +287,15 @@ def init_database(
                     'answer': problem.answer,
                 })
 
+            # 스페어 풀 적재
+            for sp in spare_problems:
+                db.session.add(SpareProblem(
+                    problem_text=sp.text,
+                    problem_type=sp.ptype,
+                    correct_answer=sp.answer,
+                ))
             db.session.commit()
-            print(f"\n{group_count}개 조, {total}명 배정 완료")
+            print(f"\n{group_count}개 조, {total}명 배정 완료 (스페어 풀 {len(spare_problems)}개)")
 
         except Exception:
             db.session.rollback()
@@ -309,6 +324,7 @@ def init_database(
         'roster_path': roster_path,
         'runners': total,
         'groups': group_count,
+        'spare_count': buffer_count,
     }
 
 

--- a/models.py
+++ b/models.py
@@ -32,6 +32,7 @@ class Runner(db.Model):
     submitted_answer = db.Column(db.String(200), nullable=True)
     next_runner_password = db.Column(db.String(20), nullable=True)
     reason = db.Column(db.String(200), nullable=True)
+    deferred_count = db.Column(db.Integer, default=0)  # 누적 미루기 횟수 (개인 랭킹 패널티용)
 
 
 class AttemptLog(db.Model):
@@ -41,3 +42,14 @@ class AttemptLog(db.Model):
     submitted_answer = db.Column(db.String(200))
     is_correct = db.Column(db.Boolean)
     submitted_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class SpareProblem(db.Model):
+    """미루기 시 새 문제로 교체하기 위한 예비 문제 풀."""
+    __tablename__ = 'spare_problems'
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    problem_text = db.Column(db.Text, nullable=False)
+    problem_type = db.Column(db.String(5), nullable=False)
+    correct_answer = db.Column(db.String(200), nullable=False)
+    consumed_at = db.Column(db.DateTime, nullable=True)  # 사용 시점 (NULL = 미사용)
+    consumed_by_runner_id = db.Column(db.Integer, db.ForeignKey('runners.id'), nullable=True)

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -24,6 +24,15 @@
               title="현재 챌린지 난이도">
             난이도: {{ 'Easy (1-hop)' if difficulty == 'easy' else 'Medium (2-hop)' }}
         </span>
+        <span class="badge {{ 'bg-secondary' if spare_remaining > 0 else 'bg-danger' }}"
+              style="font-size: 0.85rem; padding: 0.5rem 0.75rem;"
+              title="미루기 시 교체용 스페어 문제 풀">
+            스페어: {{ spare_remaining }}/{{ spare_total }}
+        </span>
+        <span class="badge bg-secondary" style="font-size: 0.85rem; padding: 0.5rem 0.75rem;"
+              title="미루기 1회당 개인 랭킹에 더해지는 패널티">
+            미루기 패널티: {{ defer_penalty_seconds }}초
+        </span>
         {% endif %}
     </div>
     <div>

--- a/templates/admin_init.html
+++ b/templates/admin_init.html
@@ -91,6 +91,25 @@
           </div>
         </div>
 
+        <div class="row g-3 mt-1">
+          <div class="col-md-6">
+            <label class="form-label" style="font-weight: 600;">미루기 패널티 (초)</label>
+            <input type="number" class="form-control" id="input-defer-penalty"
+                   value="60" min="0" max="600" step="10">
+            <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
+              미루기 1회당 개인 랭킹 elapsed에 더해지는 시간. 0 = 패널티 없음.
+            </div>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label" style="font-weight: 600;">스페어 풀 비율 (%)</label>
+            <input type="number" class="form-control" id="input-buffer-ratio"
+                   value="30" min="0" max="50" step="5">
+            <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
+              미루기 시 새 문제로 교체하기 위한 예비 풀 비율. 0% = 항상 동일 문제.
+            </div>
+          </div>
+        </div>
+
         <div class="size-box" id="size-box"></div>
         <div class="warn-banner" id="pool-warn" style="display: none;"></div>
 
@@ -649,6 +668,8 @@
       force: el('opt-force').checked,
       show_individual_ranking: el('opt-show-individual').checked,
       difficulty: el('input-difficulty').value,
+      defer_penalty_seconds: parseInt(el('input-defer-penalty').value, 10),
+      buffer_ratio: parseFloat(el('input-buffer-ratio').value) / 100,
       confirm: el('confirm-input').value,
     };
 
@@ -680,8 +701,10 @@
   };
 
   function renderDone(data) {
+    const sp = data.summary.spare_count || 0;
     el('done-summary').innerHTML =
-      `✅ 조 ${data.summary.groups}개 / 주자 ${data.summary.runners}명 / 문제 ${data.summary.problems}개 세팅 완료`;
+      `✅ 조 ${data.summary.groups}개 / 주자 ${data.summary.runners}명 / 문제 ${data.summary.problems}개`
+      + ` · 스페어 풀 ${sp}개 (미루기용 새 문제)`;
     el('done-first-player').textContent = (data.first_player_lines || []).join('\n');
     goDone();
   }

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -110,7 +110,10 @@
 <!-- 개인 랭킹 TOP N (동적) -->
 <h4 class="mt-5 mb-3" style="font-weight: 800;">개인 랭킹 TOP {{ individuals|length }}</h4>
 <p style="color: var(--text-secondary); font-size: 0.85rem; margin-top: -0.5rem;">
-    실제 답안을 제출하여 완료한 주자만 경과시간 오름차순으로 표시됩니다.
+    실제 답안을 제출하여 완료한 주자만 보정 경과시간 오름차순으로 표시됩니다.
+    {% if defer_penalty_seconds > 0 %}
+    미루기 1회당 +{{ defer_penalty_seconds }}초 패널티 적용.
+    {% endif %}
 </p>
 <div class="card">
     <div class="card-body p-0">
@@ -121,7 +124,8 @@
                         <th style="width: 60px;">순위</th>
                         <th>이름</th>
                         <th>조</th>
-                        <th>소요시간</th>
+                        <th>보정 소요시간</th>
+                        <th>원시 / 미루기</th>
                         <th>시도</th>
                     </tr>
                 </thead>
@@ -141,12 +145,18 @@
                         <td style="font-family: 'D2Coding', Consolas, monospace; font-size: 0.9rem;">
                             {{ format_timedelta(it.elapsed) }}
                         </td>
+                        <td style="font-family: 'D2Coding', Consolas, monospace; font-size: 0.85rem; color: var(--text-secondary);">
+                            {{ format_timedelta(it.raw_elapsed) }}
+                            {% if it.defers > 0 %}
+                            <span style="color: #f59e0b;">· 미루기 {{ it.defers }}회</span>
+                            {% endif %}
+                        </td>
                         <td>{{ it.runner.attempts }}</td>
                     </tr>
                     {% endfor %}
                     {% else %}
                     <tr>
-                        <td colspan="5" class="text-center" style="color: var(--text-secondary); padding: 1.5rem;">
+                        <td colspan="6" class="text-center" style="color: var(--text-secondary); padding: 1.5rem;">
                             아직 완료한 주자가 없습니다.
                         </td>
                     </tr>


### PR DESCRIPTION
Closes #26

## 요약
미루기 악용 두 가지를 동시에 차단:
1. **사전풀이 꼼수** — 미루기 시 **새 문제로 교체** (스페어 풀)
2. **쉬운 문제 가챠** — 미루기 1회당 **+N초 패널티** (개인 랭킹 보정)

## 핵심 변경
- 신규 모델 `SpareProblem` (미사용 스페어 풀)
- 기존 `Runner.deferred_count` 추가
- `init_database(buffer_ratio)`로 N+buffer 생성, 앞 N은 Runner, 나머지는 스페어 풀
- 미루기 핸들러 (self + admin) 둘 다: `deferred_count += 1` + 스페어 1건으로 문제 교체
- `get_individual_rankings(defer_penalty_seconds)`: 보정 elapsed = raw + (defers × penalty)
- 마법사 1단계: 미루기 패널티(초), 스페어 풀 비율(%) 입력
- 대시보드: 스페어 잔량 / 패널티 뱃지

## 검증
- 스페어 5/10 적재, 미루기 1회 → 문제 텍스트·정답 모두 교체, deferred_count=1, 스페어 used=1 ✓
- 보정 elapsed: raw 3분 + 미루기 3회 = 6분, raw 5분(미루기 0회)보다 뒤로 정렬 ✓
- 스페어 부족 시: 동일 문제 유지 + 경고 메시지 ✓

## 안전장치
- defer_penalty_seconds: 0~600초 검증
- buffer_ratio: 0~50% 검증
- 패널티 0초 = 관대 모드 (미루기 패널티 비활성)
- buffer 0% = 항상 동일 문제 (미루기 의미가 단순 "자리 비움"으로 회귀)

🤖 Generated with [Claude Code](https://claude.com/claude-code)