### PR TITLE
완료 후 간단 후기 작성 기능

### DIFF
--- a/app.py
+++ b/app.py
@@ -413,6 +413,29 @@ def defer():
     return redirect(url_for('index'))
 
 
+@app.route('/review', methods=['POST'])
+@login_required
+def submit_review():
+    """완료한 주자가 success 페이지에서 후기를 1회 작성한다.
+    이미 후기가 있으면 거절(수정 불가)."""
+    runner = db.session.get(Runner, session['runner_id'])
+    if not runner or runner.status not in ('completed', 'passed'):
+        flash('완료한 주자만 후기를 작성할 수 있습니다.', 'warning')
+        return redirect(url_for('index'))
+    if runner.review:
+        flash('후기는 1회만 작성할 수 있습니다.', 'info')
+        return redirect(url_for('success'))
+    text = (request.form.get('review') or '').strip()[:300]
+    if not text:
+        flash('후기 내용을 입력하세요.', 'warning')
+        return redirect(url_for('success'))
+    runner.review = text
+    runner.review_submitted_at = datetime.utcnow()
+    db.session.commit()
+    flash('후기가 저장되었습니다. 감사합니다.', 'success')
+    return redirect(url_for('success'))
+
+
 @app.route('/success')
 @login_required
 def success():
@@ -565,6 +588,9 @@ def admin_dashboard():
     spare_used = SpareProblem.query.filter(SpareProblem.consumed_at.isnot(None)).count()
     spare_remaining = spare_total - spare_used
 
+    reviews = Runner.query.filter(Runner.review.isnot(None))\
+        .order_by(Runner.review_submitted_at.desc()).all()
+
     return render_template('admin_dashboard.html',
                            groups=groups,
                            grouped=grouped,
@@ -577,7 +603,8 @@ def admin_dashboard():
                            defer_penalty_seconds=int(settings.get('defer_penalty_seconds', 0)),
                            spare_total=spare_total,
                            spare_used=spare_used,
-                           spare_remaining=spare_remaining)
+                           spare_remaining=spare_remaining,
+                           reviews=reviews)
 
 
 @app.route('/admin/skip/<int:runner_id>', methods=['POST'])

--- a/models.py
+++ b/models.py
@@ -33,6 +33,8 @@ class Runner(db.Model):
     next_runner_password = db.Column(db.String(20), nullable=True)
     reason = db.Column(db.String(200), nullable=True)
     deferred_count = db.Column(db.Integer, default=0)  # 누적 미루기 횟수 (개인 랭킹 패널티용)
+    review = db.Column(db.Text, nullable=True)         # 완료 후 후기 (선택, 최대 300자)
+    review_submitted_at = db.Column(db.DateTime, nullable=True)
 
 
 class AttemptLog(db.Model):

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -52,7 +52,10 @@
             {% endif %}
         </form>
         {% endif %}
-        <button type="button" class="btn btn-outline-secondary btn-sm ms-2" id="btn-view-first-player">firstPlayer.txt</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm ms-2" data-bs-toggle="modal" data-bs-target="#reviewsModal">
+            후기 ({{ reviews|length }})
+        </button>
+        <button type="button" class="btn btn-outline-secondary btn-sm ms-1" id="btn-view-first-player">firstPlayer.txt</button>
         <button type="button" class="btn btn-outline-secondary btn-sm ms-1" id="btn-view-roster">groupRoster.txt</button>
         <a href="{{ url_for('admin_init_download', kind='challenge-data') }}" class="btn btn-outline-secondary btn-sm ms-1">challenge_data.dat</a>
         <a href="{{ url_for('admin_init_download', kind='relay-db') }}" class="btn btn-outline-secondary btn-sm ms-1" title="SQLite DB 스냅샷">relay.db</a>
@@ -63,6 +66,38 @@
 
 <div id="admin-dashboard-data">
     {% include "_admin_groups.html" %}
+</div>
+
+<!-- 후기 모달 -->
+<div class="modal fade" id="reviewsModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content" style="background: var(--card-bg, #fff); color: var(--text-primary, #000);">
+      <div class="modal-header">
+        <h5 class="modal-title">참가자 후기 ({{ reviews|length }})</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        {% if reviews %}
+        {% for r in reviews %}
+        <div style="background: rgba(255,255,255,0.03); padding: 0.75rem 1rem; border-radius: 8px; margin-bottom: 0.6rem; border-left: 3px solid var(--samsung-blue-light);">
+          <div style="font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.35rem;">
+            <strong style="color: var(--text-primary);">{{ r.name }}</strong>
+            <span>· {{ r.group.name }} · {{ r.run_order }}번째 주자</span>
+            {% if r.review_submitted_at %}
+            <span style="margin-left: 0.5rem;">· {{ r.review_submitted_at.strftime('%m-%d %H:%M') }}</span>
+            {% endif %}
+          </div>
+          <div style="white-space: pre-wrap; word-break: break-word; font-size: 0.95rem;">{{ r.review }}</div>
+        </div>
+        {% endfor %}
+        {% else %}
+        <p style="color: var(--text-secondary); text-align: center; padding: 2rem 0;">
+          아직 작성된 후기가 없습니다.
+        </p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
 </div>
 
 <!-- groupRoster.txt 모달 (정답 포함 - 취급 주의) -->

--- a/templates/success.html
+++ b/templates/success.html
@@ -76,6 +76,33 @@
         </div>
         {% endif %}
 
+        <!-- 후기 작성 -->
+        <div class="card mb-4">
+            <div class="card-header py-3">
+                <h5 class="mb-0" style="font-weight: 700;">후기 (선택)</h5>
+            </div>
+            <div class="card-body">
+                {% if runner.review %}
+                <div style="color: var(--text-secondary); font-size: 0.85rem; margin-bottom: 0.5rem;">
+                    작성한 후기 (수정 불가)
+                </div>
+                <div style="background: rgba(255,255,255,0.03); padding: 1rem; border-radius: 8px;
+                            white-space: pre-wrap; word-break: break-word;">{{ runner.review }}</div>
+                {% else %}
+                <p style="color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 0.75rem;">
+                    난이도, 에이전트 활용 경험, 개선 제안 등 자유롭게 적어주세요. 1회만 작성 가능합니다 (최대 300자).
+                </p>
+                <form method="POST" action="{{ url_for('submit_review') }}">
+                    <textarea class="form-control mb-2" name="review" rows="3" maxlength="300"
+                              placeholder="간단한 후기를 남겨주세요..."></textarea>
+                    <div class="d-flex justify-content-end">
+                        <button type="submit" class="btn btn-samsung btn-sm">후기 저장</button>
+                    </div>
+                </form>
+                {% endif %}
+            </div>
+        </div>
+
         <div class="text-center">
             <a href="{{ url_for('leaderboard') }}" class="btn btn-samsung">
                 리더보드 보기


### PR DESCRIPTION
Closes #28

## 요약
주자가 문제 완료 후 success 페이지에서 간단한 후기를 1회 작성할 수 있도록 한다.
- 운영자 피드백 수집 (난이도·에이전트 사용감·개선점)
- 참가자 engagement

## 동작
- success 페이지 하단에 textarea + 저장 버튼 (다음 주자 비번 박스 아래)
- POST /review: 본인 + completed/passed 상태만 허용
- 1회만 작성 가능, 수정 불가 (이미 작성 시 read-only로 노출)
- 관리자 대시보드 헤더의 "후기 (N)" 버튼 → 모달에 작성자·조·시각·본문 표시
- 공개 범위: 관리자만 (참가자 페이지에는 노출 X)

## 데이터 모델
- `Runner.review`: Text, nullable, 최대 300자 (서버에서 슬라이스)
- `Runner.review_submitted_at`: DateTime, nullable

## 변경 파일
- `models.py`: 컬럼 2개 추가
- `app.py`: `/review` 라우트, admin_dashboard에 reviews 전달
- `templates/success.html`: 후기 입력/표시 카드
- `templates/admin_dashboard.html`: 후기 (N) 버튼 + 모달

## 검증 (Flask test_client)
- 기존 후기 없을 때 "후기 (0)" 노출 ✓
- 첫 POST 성공 → 본문·시각 저장 ✓
- 2번째 POST 거부 (본문 변경 없음) ✓
- 대시보드 "후기 (1)" + 본문 노출 ✓

## Test plan
- [ ] 주자 한 명 완료 → success 페이지에서 후기 입력 → 저장 → 페이지 새로고침 시 read-only로 보임
- [ ] 빈 후기 제출 시 경고
- [ ] 관리자 대시보드 "후기 (N)" 버튼 → 모달 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)