### PR TITLE
주자 마지막 활동 시각 추적 (last_seen_at)

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,6 +122,29 @@ def check_answer(submitted, correct, problem_type):
         return submitted == correct
 
 
+@app.before_request
+def _update_runner_last_seen():
+    """주자가 로그인된 상태에서 보내는 요청마다 last_seen_at 갱신.
+    30초 throttle 적용 (DB write 부하 방지)."""
+    rid = session.get('runner_id')
+    if not rid:
+        return
+    try:
+        runner = db.session.get(Runner, rid)
+    except Exception:
+        return
+    if not runner:
+        return
+    now = datetime.utcnow()
+    if runner.last_seen_at and (now - runner.last_seen_at).total_seconds() < 30:
+        return
+    runner.last_seen_at = now
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+
+
 def login_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
@@ -604,7 +627,8 @@ def admin_dashboard():
                            spare_total=spare_total,
                            spare_used=spare_used,
                            spare_remaining=spare_remaining,
-                           reviews=reviews)
+                           reviews=reviews,
+                           now_utc=datetime.utcnow())
 
 
 @app.route('/admin/skip/<int:runner_id>', methods=['POST'])
@@ -752,7 +776,8 @@ def admin_partial_groups():
                            grouped=grouped,
                            rankings=rankings,
                            total_completed=total_completed,
-                           total_runners=total_runners)
+                           total_runners=total_runners,
+                           now_utc=datetime.utcnow())
 
 
 @app.route('/admin/api/status')

--- a/models.py
+++ b/models.py
@@ -35,6 +35,7 @@ class Runner(db.Model):
     deferred_count = db.Column(db.Integer, default=0)  # 누적 미루기 횟수 (개인 랭킹 패널티용)
     review = db.Column(db.Text, nullable=True)         # 완료 후 후기 (선택, 최대 300자)
     review_submitted_at = db.Column(db.DateTime, nullable=True)
+    last_seen_at = db.Column(db.DateTime, nullable=True)  # 마지막 활동 시각 (온라인 여부 추정용)
 
 
 class AttemptLog(db.Model):

--- a/templates/_admin_groups.html
+++ b/templates/_admin_groups.html
@@ -81,6 +81,19 @@
                                 {% elif runner.status == 'skipped' %}건너뜀
                                 {% endif %}
                             </span>
+                            {% if runner.status == 'active' and runner.last_seen_at %}
+                                {% set since = (now_utc - runner.last_seen_at).total_seconds() %}
+                                {% if since <= 300 %}
+                                <span title="최근 활동 (5분 이내)" style="color: #22c55e; margin-left: 0.3rem;">🟢</span>
+                                {% else %}
+                                <span title="마지막 활동" style="color: var(--text-secondary); font-size: 0.75rem; margin-left: 0.3rem;">
+                                    {% if since < 3600 %}{{ (since / 60)|int }}분 전
+                                    {% else %}{{ (since / 3600)|int }}시간 전{% endif %}
+                                </span>
+                                {% endif %}
+                            {% elif runner.status == 'active' %}
+                                <span title="아직 로그인 기록 없음" style="color: var(--text-secondary); font-size: 0.75rem; margin-left: 0.3rem;">미접속</span>
+                            {% endif %}
                         </td>
                         <td>
                             {% if runner.password %}


### PR DESCRIPTION
Closes #30

## 요약
관리자가 active 주자의 현재 활동 여부를 추정할 수 있게 last_seen_at 추적.

- HTTP는 stateless라 \"로그인 상태\" 직접 측정 불가
- 표준 방식인 \"마지막 요청 시각\" 기반으로 \"최근 5분 활동했나\" 표시

## 구현
- \`Runner.last_seen_at\` DateTime 추가
- \`@app.before_request\`에서 \`session['runner_id']\` 있으면 갱신 (30초 throttle)
- 관리자 대시보드 (active 행에서만):
  - 🟢: 5분 이내 활동
  - \"X분 전\" / \"X시간 전\": 그 외
  - \"미접속\": last_seen_at 없음

## 검증
- 활동 2분 전 → 🟢 1개 ✓
- 10분 전 → \"10분 전\" 표시 ✓
- last_seen_at None인 active → \"미접속\" 표시 ✓
- 일반 요청 → last_seen_at 갱신 ✓
- 30초 이내 재요청 → throttled (DB write 없음) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)