### PR TITLE
마법사에 데이터셋 시드 입력 옵션

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ DEFAULT_SETTINGS = {
     'difficulty': 'medium',      # easy | medium (hard는 차후)
     'defer_penalty_seconds': 0,  # 미루기 1회당 개인 랭킹에 더해지는 패널티 (초). 0 = 패널티 없음
     'buffer_ratio': 0.3,         # 스페어 풀 비율 (전체 인원 대비)
+    'seed': 2026,                # 데이터셋 시드 (부서별 다른 데이터/답을 쓰고 싶을 때)
 }
 
 
@@ -624,6 +625,7 @@ def admin_dashboard():
                            initialized=initialized,
                            difficulty=settings.get('difficulty', 'medium'),
                            defer_penalty_seconds=int(settings.get('defer_penalty_seconds', 0)),
+                           seed=int(settings.get('seed', 2026)),
                            spare_total=spare_total,
                            spare_used=spare_used,
                            spare_remaining=spare_remaining,
@@ -1105,15 +1107,19 @@ def admin_init_commit():
     try:
         defer_penalty_seconds = int(data.get('defer_penalty_seconds', 0))
         buffer_ratio = float(data.get('buffer_ratio', 0.3))
+        seed = int(data.get('seed', 2026))
     except (TypeError, ValueError):
         return jsonify({'ok': False, 'error_code': 'VALIDATION',
-                        'message': 'defer_penalty_seconds/buffer_ratio 형식 오류'}), 400
+                        'message': 'defer_penalty_seconds/buffer_ratio/seed 형식 오류'}), 400
     if not (0 <= defer_penalty_seconds <= 600):
         return jsonify({'ok': False, 'error_code': 'VALIDATION',
                         'message': '미루기 패널티는 0~600초 범위'}), 400
     if not (0.0 <= buffer_ratio <= 0.5):
         return jsonify({'ok': False, 'error_code': 'VALIDATION',
                         'message': '스페어 풀 비율은 0~50% 범위'}), 400
+    if not (1 <= seed <= 999999):
+        return jsonify({'ok': False, 'error_code': 'VALIDATION',
+                        'message': '시드는 1~999999 범위 정수'}), 400
 
     # 6) init_database 실행 — 세션/엔진을 먼저 닫아야 Windows에서 DB 파일 삭제 가능
     db.session.remove()
@@ -1128,6 +1134,7 @@ def admin_init_commit():
             regen_challenge_data=regen,
             difficulty=difficulty,
             buffer_ratio=buffer_ratio,
+            seed=seed,
         )
     except Exception as e:
         return jsonify({
@@ -1145,6 +1152,7 @@ def admin_init_commit():
             'difficulty': difficulty,
             'defer_penalty_seconds': defer_penalty_seconds,
             'buffer_ratio': buffer_ratio,
+            'seed': seed,
         })
     except OSError:
         pass  # 파일 쓰기 실패해도 초기화 자체는 성공으로 간주

--- a/generate_challenge.py
+++ b/generate_challenge.py
@@ -996,17 +996,18 @@ def _scaled_data_sizes(total_problems: int) -> dict:
 DIFFICULTY_LEVELS = ('easy', 'medium')  # 'hard'는 이번 범위 밖
 
 
-def _build_pools(total_problems: int, difficulty: str = 'medium'):
+def _build_pools(total_problems: int, difficulty: str = 'medium', seed: int = SEED):
     """유형별 풀을 생성해 (pools, data_bundle) 반환. 내부에서 seed 재설정.
 
     difficulty:
-      - 'easy'  : Type A/C/D/E (1-hop, 4유형)
-      - 'medium': Type F/G/H/I/J (2-hop, 5유형) — 현재 2차 기본
+      - 'easy'  : Type A/B/C/D/E
+      - 'medium': Type F/G/H/I/J (2-hop 균일)
+    seed: 데이터·문제 생성 시드. 기본 SEED(2026).
     """
     if difficulty not in DIFFICULTY_LEVELS:
         raise ValueError(f"unknown difficulty: {difficulty!r} (allowed: {DIFFICULTY_LEVELS})")
 
-    random.seed(SEED)
+    random.seed(seed)
     sizes = _scaled_data_sizes(total_problems)
 
     employees = generate_employees(sizes["n_employees"])
@@ -1307,17 +1308,18 @@ def create_excel(all_problems, filename="challenge_admin.xlsx"):
 # ============================================================
 def main(total_problems: int = DEFAULT_TOTAL_PROBLEMS,
          difficulty: str = 'medium',
+         seed: int = SEED,
          output_path: str = "challenge_data.dat",
          excel_path: str = "challenge_admin.xlsx"):
     if difficulty not in DIFFICULTY_LEVELS:
         raise ValueError(f"unknown difficulty: {difficulty!r}")
 
     print("=" * 60)
-    print(f"코딩 에이전트 릴레이 설치 챌린지 (N={total_problems}, difficulty={difficulty})")
+    print(f"코딩 에이전트 릴레이 설치 챌린지 (N={total_problems}, difficulty={difficulty}, seed={seed})")
     print("=" * 60)
 
     # 1~3. 섹션 데이터 생성 + challenge_data.dat 작성 + 풀 빌드
-    pools, bundle = _build_pools(total_problems, difficulty=difficulty)
+    pools, bundle = _build_pools(total_problems, difficulty=difficulty, seed=seed)
     all_sections = bundle["all_sections"]
 
     print(f"  총 {len(all_sections)}개 섹션 생성")
@@ -1376,9 +1378,10 @@ def main(total_problems: int = DEFAULT_TOTAL_PROBLEMS,
 
 
 def get_all_problems(total_problems: int = DEFAULT_TOTAL_PROBLEMS,
-                     difficulty: str = 'medium'):
+                     difficulty: str = 'medium',
+                     seed: int = SEED):
     """외부에서 호출하여 total_problems개 문제 목록을 반환."""
-    pools, _bundle = _build_pools(total_problems, difficulty=difficulty)
+    pools, _bundle = _build_pools(total_problems, difficulty=difficulty, seed=seed)
     total_generated = sum(len(p) for p in pools)
     if total_generated < total_problems:
         raise RuntimeError(
@@ -1391,12 +1394,19 @@ if __name__ == "__main__":
     import sys
     n = DEFAULT_TOTAL_PROBLEMS
     diff = 'medium'
+    sd = SEED
     if len(sys.argv) > 1:
         try:
             n = int(sys.argv[1])
         except ValueError:
-            print(f"사용법: python generate_challenge.py [total_problems] [easy|medium]")
+            print(f"사용법: python generate_challenge.py [total_problems] [easy|medium] [seed]")
             sys.exit(1)
     if len(sys.argv) > 2:
         diff = sys.argv[2]
-    main(total_problems=n, difficulty=diff)
+    if len(sys.argv) > 3:
+        try:
+            sd = int(sys.argv[3])
+        except ValueError:
+            print(f"seed는 정수여야 합니다.")
+            sys.exit(1)
+    main(total_problems=n, difficulty=diff, seed=sd)

--- a/init_db.py
+++ b/init_db.py
@@ -106,6 +106,7 @@ def init_database(
     regen_challenge_data: bool = False,
     difficulty: str = 'medium',
     buffer_ratio: float = 0.3,
+    seed: int = 2026,
 ) -> dict:
     """
     DB를 삭제 후 재생성하고 참가자·조·문제를 배정한다.
@@ -149,10 +150,11 @@ def init_database(
 
     # 문제 풀 재생성 (필요 시)
     if regen_challenge_data:
-        print(f"challenge_data.dat 재생성 (N={grand_total} = 본 {total} + 스페어 {buffer_count}, difficulty={difficulty})...")
+        print(f"challenge_data.dat 재생성 (N={grand_total} = 본 {total} + 스페어 {buffer_count}, difficulty={difficulty}, seed={seed})...")
         generate_main(
             total_problems=grand_total,
             difficulty=difficulty,
+            seed=seed,
             output_path=os.path.join(BASE_DIR, "challenge_data.dat"),
             excel_path=os.path.join(BASE_DIR, "challenge_admin.xlsx"),
         )
@@ -184,8 +186,8 @@ def init_database(
 
         try:
             # 1. 문제 로드 (총 grand_total개 = 본 + 스페어)
-            print(f"{grand_total}개 문제 로드 중 (본 {total} + 스페어 {buffer_count}, difficulty={difficulty})...")
-            problems = get_all_problems(total_problems=grand_total, difficulty=difficulty)
+            print(f"{grand_total}개 문제 로드 중 (본 {total} + 스페어 {buffer_count}, difficulty={difficulty}, seed={seed})...")
+            problems = get_all_problems(total_problems=grand_total, difficulty=difficulty, seed=seed)
             if len(problems) < grand_total:
                 raise RuntimeError(
                     f"문제 부족: 요청 {grand_total}개, 생성 {len(problems)}개. "

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -33,6 +33,10 @@
               title="미루기 1회당 개인 랭킹에 더해지는 패널티">
             미루기 패널티: {{ defer_penalty_seconds }}초
         </span>
+        <span class="badge bg-secondary" style="font-size: 0.85rem; padding: 0.5rem 0.75rem;"
+              title="데이터셋 시드 — 같은 시드면 동일 데이터·답">
+            시드: {{ seed }}
+        </span>
         {% endif %}
     </div>
     <div>

--- a/templates/admin_init.html
+++ b/templates/admin_init.html
@@ -114,7 +114,7 @@
             <input type="number" class="form-control" id="input-seed"
                    value="2026" min="1" max="999999" step="1">
             <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
-              부서별 다른 시드 → 다른 데이터·답.
+              1~999999 (최대 6자리). 부서별 다른 시드 → 다른 데이터·답.
             </div>
           </div>
         </div>

--- a/templates/admin_init.html
+++ b/templates/admin_init.html
@@ -101,12 +101,20 @@
               새 문제 교체로 사전풀이 꼼수가 차단되므로 보통 0 권장.
             </div>
           </div>
-          <div class="col-md-6">
+          <div class="col-md-4">
             <label class="form-label" style="font-weight: 600;">스페어 풀 비율 (%)</label>
             <input type="number" class="form-control" id="input-buffer-ratio"
                    value="30" min="0" max="50" step="5">
             <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
               미루기 시 새 문제로 교체하기 위한 예비 풀 비율. 0% = 항상 동일 문제.
+            </div>
+          </div>
+          <div class="col-md-2">
+            <label class="form-label" style="font-weight: 600;">데이터셋 시드</label>
+            <input type="number" class="form-control" id="input-seed"
+                   value="2026" min="1" max="999999" step="1">
+            <div style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.25rem;">
+              부서별 다른 시드 → 다른 데이터·답.
             </div>
           </div>
         </div>
@@ -671,6 +679,7 @@
       difficulty: el('input-difficulty').value,
       defer_penalty_seconds: parseInt(el('input-defer-penalty').value, 10),
       buffer_ratio: parseFloat(el('input-buffer-ratio').value) / 100,
+      seed: parseInt(el('input-seed').value, 10),
       confirm: el('confirm-input').value,
     };
 


### PR DESCRIPTION
Closes #32

## 요약
\`generate_challenge.SEED\` 상수를 마법사에서 직접 지정할 수 있게 한다. 부서별 다른 시드 → 같은 구조·난이도지만 데이터·답이 모두 달라 부서 간 답 공유 방지.

## 변경
- generate_challenge: \`main(seed)\`, \`_build_pools(seed)\`, \`get_all_problems(seed)\`, CLI 3번째 인자
- init_db: \`init_database(seed)\` 파라미터, generate_main 및 get_all_problems 호출 시 전달
- app: admin_init_commit이 seed 받아 init·settings에 저장 (1~999999 검증)
- admin_init.html: 1단계에 시드 입력 (기본 2026)
- admin_dashboard.html: 현재 시드 뱃지

## 검증
- 같은 seed=2026 두 번 호출 → 동일 답 ✓
- seed=2026 vs seed=9999 → 모든 답 다름 ✓
- seed=0 거부 (400 VALIDATION) ✓
- 웹 commit으로 settings.json에 seed 저장 확인 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)