### PR TITLE
공개 명단 페이지(/roster) 추가

### DIFF
--- a/app.py
+++ b/app.py
@@ -539,6 +539,18 @@ def guide():
     return render_template('guide.html')
 
 
+@app.route('/roster')
+@challenge_open_required
+def roster():
+    """조별 주자 명단 공개 페이지. 비번/정답/후기 등 민감 정보는 제외."""
+    groups = Group.query.order_by(Group.id).all()
+    grouped = {g.id: [] for g in groups}
+    runners = Runner.query.order_by(Runner.group_id, Runner.run_order).all()
+    for r in runners:
+        grouped[r.group_id].append(r)
+    return render_template('roster.html', groups=groups, grouped=grouped)
+
+
 @app.route('/download/challenge_data')
 @challenge_open_required
 def download_challenge_data():

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,9 @@
                         <a class="nav-link" href="{{ url_for('leaderboard') }}">리더보드</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('roster') }}">조 편성</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('guide') }}">설치 가이드</a>
                     </li>
                     <li class="nav-item">

--- a/templates/roster.html
+++ b/templates/roster.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+
+{% block title %}조 편성{% endblock %}
+
+{% block content %}
+<div class="hero" style="padding: 2rem 0 1.5rem;">
+    <h1>조 편성</h1>
+    <p>본인 Knox-ID로 자기 조·순서를 미리 확인하세요. 차례가 되면 이전 주자에게 비밀번호를 전달받아 로그인하시면 됩니다.</p>
+</div>
+
+<!-- Knox-ID 빠른 검색 -->
+<div class="card mb-4">
+    <div class="card-body py-3">
+        <div class="d-flex align-items-center gap-2 flex-wrap">
+            <label for="roster-search" style="font-weight: 600; margin-bottom: 0;">내 Knox-ID 검색:</label>
+            <input type="text" id="roster-search" class="form-control" style="max-width: 280px;"
+                   placeholder="knox_id 입력 시 본인 행으로 이동" autocomplete="off">
+            <button type="button" class="btn btn-outline-secondary btn-sm" id="roster-clear">초기화</button>
+        </div>
+    </div>
+</div>
+
+{% for group in groups %}
+{% set runners = grouped.get(group.id, []) %}
+<div class="card mb-3">
+    <div class="card-header py-2 d-flex justify-content-between align-items-center">
+        <strong>{{ group.name }}</strong>
+        <span style="color: var(--text-secondary); font-size: 0.85rem;">{{ runners|length }}명</span>
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-dark-custom mb-0">
+                <thead>
+                    <tr>
+                        <th style="width: 60px;">순서</th>
+                        <th>이름</th>
+                        <th>Knox-ID</th>
+                        <th style="width: 100px;">상태</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for r in runners %}
+                    <tr data-knox="{{ r.knox_id|lower }}">
+                        <td style="font-weight: 600;">{{ r.run_order }}</td>
+                        <td>{{ r.name }}</td>
+                        <td><code>{{ r.knox_id }}</code></td>
+                        <td>
+                            <span class="badge-status badge-{{ r.status }}">
+                                {% if r.status == 'waiting' %}대기
+                                {% elif r.status == 'active' %}진행 중
+                                {% elif r.status == 'completed' %}완료
+                                {% elif r.status == 'passed' %}PASS
+                                {% elif r.status == 'skipped' %}건너뜀
+                                {% endif %}
+                            </span>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endfor %}
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+    const input = document.getElementById('roster-search');
+    const clearBtn = document.getElementById('roster-clear');
+    const HIGHLIGHT = 'rgba(245,158,11,0.18)';
+    let lastHighlighted = null;
+
+    function clearHighlight() {
+        if (lastHighlighted) {
+            lastHighlighted.style.background = '';
+            lastHighlighted = null;
+        }
+    }
+
+    function find() {
+        const q = input.value.trim().toLowerCase();
+        clearHighlight();
+        if (!q) return;
+        const row = document.querySelector(`tr[data-knox="${q}"]`);
+        if (!row) return;
+        row.style.background = HIGHLIGHT;
+        row.scrollIntoView({behavior: 'smooth', block: 'center'});
+        lastHighlighted = row;
+    }
+
+    input.addEventListener('input', find);
+    clearBtn.addEventListener('click', () => {
+        input.value = '';
+        clearHighlight();
+    });
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
Closes #35

## 요약
2~13번 주자가 차례 도래 전에 본인 조·순서를 사전에 확인할 수 있도록 \`/roster\` 공개 페이지 추가.

## 변경
- \`/roster\` 라우트 (\`challenge_open_required\`)
- 조별 그룹핑된 명단 (순서/이름/Knox-ID/상태)
- 비밀번호·정답·후기 등 민감 정보 미노출
- Knox-ID 검색 박스: 본인 행으로 자동 스크롤 + 하이라이트
- nav에 \"조 편성\" 링크 추가

## 노출 정보
- group, run_order, name, knox_id, status (모두 리더보드/대시보드에 이미 일부 노출되는 정보의 합집합 + run_order)

## Test plan
- [ ] 챌린지 공개 상태에서 /roster 접근 → 모든 조·주자 표시
- [ ] 비공개 상태에서는 \"준비 중\" 페이지로
- [ ] Knox-ID 검색 시 해당 행 하이라이트 + 자동 스크롤
- [ ] nav의 \"조 편성\" 링크 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)