### PR TITLE
미루기: 특정 주자와 순서 교환 옵션

### DIFF
--- a/app.py
+++ b/app.py
@@ -390,7 +390,10 @@ def submit():
 @app.route('/defer', methods=['POST'])
 @login_required
 def defer():
-    """주자 본인이 자기 차례를 조 맨 뒤로 미룸."""
+    """주자 본인이 자기 차례를 N칸 뒤로 이동.
+    steps=N: 본인이 X번 주자라면 (X+N)번 자리로 이동. 사이 주자 N명은 1칸씩 앞당겨짐.
+    N == max_steps(=max_order - X)면 맨 뒤로 미루는 효과.
+    """
     runner = db.session.get(Runner, session['runner_id'])
     if not runner or runner.status != 'active':
         flash('현재 진행 중인 주자만 미룰 수 있습니다.', 'warning')
@@ -399,21 +402,33 @@ def defer():
     old_order = runner.run_order
     max_order = db.session.query(db.func.max(Runner.run_order))\
         .filter_by(group_id=runner.group_id).scalar()
+    max_steps = max_order - old_order
 
-    if old_order == max_order:
+    if max_steps < 1:
         flash('이미 마지막 주자라 더 미룰 수 없습니다.', 'info')
         return redirect(url_for('challenge'))
 
-    # 뒤에 있는 주자들을 1씩 당김
-    later_runners = Runner.query.filter(
+    try:
+        steps = int(request.form.get('steps', 0))
+    except (TypeError, ValueError):
+        steps = 0
+    if steps < 1 or steps > max_steps:
+        flash(f'이동 칸 수는 1~{max_steps} 범위여야 합니다.', 'warning')
+        return redirect(url_for('challenge'))
+
+    new_order = old_order + steps
+
+    # 사이 주자(old_order < x ≤ new_order)들은 1씩 앞당김
+    between_runners = Runner.query.filter(
         Runner.group_id == runner.group_id,
-        Runner.run_order > old_order
+        Runner.run_order > old_order,
+        Runner.run_order <= new_order,
     ).order_by(Runner.run_order).all()
-    for r in later_runners:
+    for r in between_runners:
         r.run_order -= 1
 
     reason = request.form.get('reason', '').strip()[:200]
-    runner.run_order = max_order
+    runner.run_order = new_order
     runner.status = 'waiting'
     runner.password = ''
     runner.started_at = None
@@ -425,10 +440,10 @@ def defer():
     # 새 문제로 교체 (스페어 풀에서 1건). 풀 비어있으면 동일 문제 유지.
     swapped = _swap_with_spare_problem(runner)
 
-    # 당겨진 순서에 있는 waiting 주자 활성화
+    # 당겨진 순서(old_order)의 waiting 주자 활성화
     next_runner = Runner.query.filter_by(
         group_id=runner.group_id,
-        run_order=old_order
+        run_order=old_order,
     ).first()
     if next_runner and next_runner.status == 'waiting':
         password = generate_password()
@@ -437,10 +452,8 @@ def defer():
 
     db.session.commit()
     session.pop('runner_id', None)
-    if swapped:
-        flash('차례를 맨 뒤로 미뤘습니다. 다음 차례에는 새 문제가 출제됩니다.', 'info')
-    else:
-        flash('차례를 맨 뒤로 미뤘습니다. (스페어 풀 부족: 동일 문제 유지)', 'warning')
+    suffix = '' if swapped else ' (스페어 풀 부족: 동일 문제 유지)'
+    flash(f'{steps}칸 뒤로 이동했습니다. 차례가 다시 돌아오면 새 문제가 출제됩니다.{suffix}', 'info')
     return redirect(url_for('index'))
 
 

--- a/app.py
+++ b/app.py
@@ -334,6 +334,13 @@ def challenge():
 
     if runner.status in ('completed', 'passed'):
         return redirect(url_for('success'))
+    # 미루기/교환 직후 (waiting + next_runner_password): 결과 페이지로
+    if runner.status == 'waiting' and runner.next_runner_password:
+        return redirect(url_for('defer_result'))
+    if runner.status != 'active':
+        flash('현재 진행 중인 주자만 접속할 수 있습니다.', 'warning')
+        session.pop('runner_id', None)
+        return redirect(url_for('index'))
 
     # 순서 교환 후보: 같은 조에서 본인보다 뒤이면서 대기 중인 주자
     swap_candidates = Runner.query.filter(
@@ -440,21 +447,22 @@ def defer():
     # 새 문제로 교체 (스페어 풀에서 1건). 풀 비어있으면 동일 문제 유지.
     swapped = _swap_with_spare_problem(runner)
 
-    # 당겨진 순서(old_order)의 waiting 주자 활성화
+    # 당겨진 순서(old_order)의 waiting 주자 활성화 + 새 비번을 본인에게도 전달용으로 저장
     next_runner = Runner.query.filter_by(
         group_id=runner.group_id,
         run_order=old_order,
     ).first()
+    new_password = None
     if next_runner and next_runner.status == 'waiting':
-        password = generate_password()
-        next_runner.password = password
+        new_password = generate_password()
+        next_runner.password = new_password
         next_runner.status = 'active'
+        runner.next_runner_password = new_password
 
     db.session.commit()
-    session.pop('runner_id', None)
     suffix = '' if swapped else ' (스페어 풀 부족: 동일 문제 유지)'
-    flash(f'{steps}칸 뒤로 이동했습니다. 차례가 다시 돌아오면 새 문제가 출제됩니다.{suffix}', 'info')
-    return redirect(url_for('index'))
+    flash(f'{steps}칸 뒤로 이동했습니다. 다음 주자에게 비밀번호를 전달하세요.{suffix}', 'info')
+    return redirect(url_for('defer_result'))
 
 
 @app.route('/defer/swap', methods=['POST'])
@@ -501,18 +509,36 @@ def defer_swap():
     runner.reason = reason or None
     swapped = _swap_with_spare_problem(runner)
 
-    # 대상 주자 활성화
-    password = generate_password()
-    target.password = password
+    # 대상 주자 활성화 + 새 비번을 본인 next_runner_password에도 저장
+    new_password = generate_password()
+    target.password = new_password
     target.status = 'active'
+    runner.next_runner_password = new_password
 
     db.session.commit()
-    session.pop('runner_id', None)
-    if swapped:
-        flash(f'{target.name}님과 순서를 바꿨습니다. 다시 차례가 오면 새 문제가 출제됩니다.', 'info')
-    else:
-        flash(f'{target.name}님과 순서를 바꿨습니다. (스페어 부족: 동일 문제 유지)', 'warning')
-    return redirect(url_for('index'))
+    suffix = '' if swapped else ' (스페어 풀 부족: 동일 문제 유지)'
+    flash(f'{target.name}님과 순서를 바꿨습니다. 그분에게 비밀번호를 전달하세요.{suffix}', 'info')
+    return redirect(url_for('defer_result'))
+
+
+@app.route('/defer/result')
+@login_required
+def defer_result():
+    """미루기/교환 직후 안내 페이지 — 새 활성 주자 정보와 비밀번호 표시."""
+    runner = db.session.get(Runner, session['runner_id'])
+    if not runner:
+        return redirect(url_for('index'))
+    # 본인이 미루기 직후 상태 — waiting + next_runner_password 채워져 있어야 함
+    if runner.status != 'waiting' or not runner.next_runner_password:
+        return redirect(url_for('index'))
+    # 새 활성 주자 = 같은 조에서 status='active' 인 주자 (방금 활성화된 사람)
+    new_active = Runner.query.filter_by(
+        group_id=runner.group_id, status='active',
+    ).first()
+    return render_template('defer_result.html',
+                           runner=runner,
+                           new_active=new_active,
+                           next_password=runner.next_runner_password)
 
 
 @app.route('/review', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -705,6 +705,17 @@ def admin_dashboard():
     reviews = Runner.query.filter(Runner.review.isnot(None))\
         .order_by(Runner.review_submitted_at.desc()).all()
 
+    # 미루기 모달용: 각 주자별 교환 후보 (같은 조 + 본인 뒤 + waiting)
+    defer_candidates = {}
+    for r in all_runners:
+        if r.status in ('waiting', 'active'):
+            cands = [c for c in grouped[r.group_id]
+                     if c.status == 'waiting' and c.run_order > r.run_order]
+            defer_candidates[r.id] = [
+                {'order': c.run_order, 'name': c.name, 'knox_id': c.knox_id}
+                for c in cands
+            ]
+
     return render_template('admin_dashboard.html',
                            groups=groups,
                            grouped=grouped,
@@ -720,7 +731,8 @@ def admin_dashboard():
                            spare_used=spare_used,
                            spare_remaining=spare_remaining,
                            reviews=reviews,
-                           now_utc=datetime.utcnow())
+                           now_utc=datetime.utcnow(),
+                           defer_candidates=defer_candidates)
 
 
 @app.route('/admin/skip/<int:runner_id>', methods=['POST'])
@@ -765,6 +777,11 @@ def admin_pass(runner_id):
 @app.route('/admin/defer/<int:runner_id>', methods=['POST'])
 @admin_required
 def admin_defer(runner_id):
+    """관리자 미루기. mode 파라미터:
+    - 'max'(기본): 조 맨 뒤로 (기존 동작)
+    - 'steps': steps 칸 뒤로
+    - 'swap':  target_order 의 waiting 주자와 1:1 교환
+    """
     runner = Runner.query.get_or_404(runner_id)
     if runner.status not in ('waiting', 'active'):
         flash('대기 중 또는 진행 중인 주자만 미룰 수 있습니다.', 'warning')
@@ -773,49 +790,90 @@ def admin_defer(runner_id):
     was_active = runner.status == 'active'
     old_order = runner.run_order
 
-    # 조의 마지막 run_order 조회
     max_order = db.session.query(db.func.max(Runner.run_order))\
         .filter_by(group_id=runner.group_id).scalar()
-
     if old_order == max_order:
         flash(f'{runner.name}은(는) 이미 마지막 주자입니다.', 'info')
         return redirect(url_for('admin_dashboard'))
 
-    # old_order보다 뒤에 있는 waiting 주자들의 순서를 1씩 당기기
-    later_runners = Runner.query.filter(
-        Runner.group_id == runner.group_id,
-        Runner.run_order > old_order
-    ).order_by(Runner.run_order).all()
+    mode = request.form.get('mode', 'max')
+    reason = request.form.get('reason', '').strip()[:200]
 
-    for r in later_runners:
-        r.run_order -= 1
+    # ---- swap 모드 ----
+    if mode == 'swap':
+        try:
+            target_order = int(request.form.get('target_order', 0))
+        except (TypeError, ValueError):
+            target_order = 0
+        target = Runner.query.filter_by(
+            group_id=runner.group_id, run_order=target_order, status='waiting',
+        ).first()
+        if not target or target.run_order <= old_order:
+            msg = '대상 주자가 유효하지 않습니다 (본인 뒤의 대기 주자만 가능).'
+            if _is_ajax():
+                return jsonify({'ok': False, 'message': msg}), 400
+            flash(msg, 'warning')
+            return redirect(url_for('admin_dashboard'))
+        # 1:1 swap
+        runner.run_order = target.run_order
+        target.run_order = old_order
+        if was_active:
+            password = generate_password()
+            target.password = password
+            target.status = 'active'
+        new_order = runner.run_order
+    # ---- steps / max 모드 ----
+    else:
+        if mode == 'steps':
+            try:
+                steps = int(request.form.get('steps', 0))
+            except (TypeError, ValueError):
+                steps = 0
+            max_steps = max_order - old_order
+            if steps < 1 or steps > max_steps:
+                msg = f'이동 칸 수는 1~{max_steps} 범위여야 합니다.'
+                if _is_ajax():
+                    return jsonify({'ok': False, 'message': msg}), 400
+                flash(msg, 'warning')
+                return redirect(url_for('admin_dashboard'))
+            new_order = old_order + steps
+        else:  # 'max'
+            new_order = max_order
 
-    # 해당 주자를 맨 뒤로 (시작 시간 초기화 + 미루기 카운트 +1 + 새 문제 교체)
-    runner.run_order = max_order
+        # 사이 주자(old_order < x ≤ new_order) 1칸씩 앞당김
+        between = Runner.query.filter(
+            Runner.group_id == runner.group_id,
+            Runner.run_order > old_order,
+            Runner.run_order <= new_order,
+        ).order_by(Runner.run_order).all()
+        for r in between:
+            r.run_order -= 1
+        runner.run_order = new_order
+
+        if was_active:
+            next_runner = Runner.query.filter_by(
+                group_id=runner.group_id, run_order=old_order,
+            ).first()
+            if next_runner and next_runner.status == 'waiting':
+                password = generate_password()
+                next_runner.password = password
+                next_runner.status = 'active'
+
+    # 공통: 본인 리셋 + 새 문제 교체 + 미루기 카운트
     runner.status = 'waiting'
     runner.password = ''
     runner.started_at = None
     runner.attempts = 0
     runner.deferred_count = (runner.deferred_count or 0) + 1
     runner.submitted_answer = None
+    runner.reason = reason or None
     swapped = _swap_with_spare_problem(runner)
-
-    # active였으면 다음 주자(당겨진 순서) 활성화
-    if was_active:
-        next_runner = Runner.query.filter_by(
-            group_id=runner.group_id,
-            run_order=old_order
-        ).first()
-        if next_runner and next_runner.status == 'waiting':
-            password = generate_password()
-            next_runner.password = password
-            next_runner.status = 'active'
 
     db.session.commit()
     if _is_ajax():
-        return jsonify({'ok': True, 'swapped': swapped})
+        return jsonify({'ok': True, 'swapped': swapped, 'new_order': new_order})
     msg_suffix = '' if swapped else ' (스페어 풀 부족: 동일 문제 유지)'
-    flash(f'{runner.name}을(를) 맨 뒤로 미뤘습니다. (새 순서: {max_order}번째){msg_suffix}', 'info')
+    flash(f'{runner.name}을(를) {new_order}번째로 이동했습니다.{msg_suffix}', 'info')
     return redirect(url_for('admin_dashboard'))
 
 
@@ -863,13 +921,23 @@ def admin_partial_groups():
     rankings = get_group_rankings()
     total_completed = sum(r['completed'] for r in rankings)
     total_runners = sum(r['total'] for r in rankings)
+    defer_candidates = {}
+    for r in all_runners:
+        if r.status in ('waiting', 'active'):
+            cands = [c for c in grouped[r.group_id]
+                     if c.status == 'waiting' and c.run_order > r.run_order]
+            defer_candidates[r.id] = [
+                {'order': c.run_order, 'name': c.name, 'knox_id': c.knox_id}
+                for c in cands
+            ]
     return render_template('_admin_groups.html',
                            groups=groups,
                            grouped=grouped,
                            rankings=rankings,
                            total_completed=total_completed,
                            total_runners=total_runners,
-                           now_utc=datetime.utcnow())
+                           now_utc=datetime.utcnow(),
+                           defer_candidates=defer_candidates)
 
 
 @app.route('/admin/api/status')

--- a/app.py
+++ b/app.py
@@ -335,7 +335,14 @@ def challenge():
     if runner.status in ('completed', 'passed'):
         return redirect(url_for('success'))
 
-    return render_template('challenge.html', runner=runner)
+    # 순서 교환 후보: 같은 조에서 본인보다 뒤이면서 대기 중인 주자
+    swap_candidates = Runner.query.filter(
+        Runner.group_id == runner.group_id,
+        Runner.run_order > runner.run_order,
+        Runner.status == 'waiting',
+    ).order_by(Runner.run_order).all()
+
+    return render_template('challenge.html', runner=runner, swap_candidates=swap_candidates)
 
 
 @app.route('/submit', methods=['POST'])
@@ -434,6 +441,64 @@ def defer():
         flash('차례를 맨 뒤로 미뤘습니다. 다음 차례에는 새 문제가 출제됩니다.', 'info')
     else:
         flash('차례를 맨 뒤로 미뤘습니다. (스페어 풀 부족: 동일 문제 유지)', 'warning')
+    return redirect(url_for('index'))
+
+
+@app.route('/defer/swap', methods=['POST'])
+@login_required
+def defer_swap():
+    """본인 차례를 같은 조의 특정 미진행 주자(run_order 더 뒤, status='waiting')와 교환."""
+    runner = db.session.get(Runner, session['runner_id'])
+    if not runner or runner.status != 'active':
+        flash('현재 진행 중인 주자만 사용할 수 있습니다.', 'warning')
+        return redirect(url_for('index'))
+
+    try:
+        target_order = int(request.form.get('target_order', 0))
+    except ValueError:
+        flash('대상 순서를 선택하세요.', 'warning')
+        return redirect(url_for('challenge'))
+
+    target = Runner.query.filter_by(
+        group_id=runner.group_id,
+        run_order=target_order,
+        status='waiting',
+    ).first()
+    if not target:
+        flash('해당 순서의 대기 중인 주자를 찾을 수 없습니다.', 'warning')
+        return redirect(url_for('challenge'))
+    if target.id == runner.id or target.run_order <= runner.run_order:
+        flash('본인보다 뒤의 대기 중인 주자만 선택할 수 있습니다.', 'warning')
+        return redirect(url_for('challenge'))
+
+    reason = request.form.get('reason', '').strip()[:200]
+    my_order = runner.run_order
+
+    # 순서 교환 — 두 주자의 run_order만 swap (다른 주자는 영향 없음)
+    runner.run_order = target.run_order
+    target.run_order = my_order
+
+    # 본인은 waiting으로, 새 문제 교체, 미루기 카운트 증가
+    runner.status = 'waiting'
+    runner.password = ''
+    runner.started_at = None
+    runner.attempts = 0
+    runner.deferred_count = (runner.deferred_count or 0) + 1
+    runner.submitted_answer = None
+    runner.reason = reason or None
+    swapped = _swap_with_spare_problem(runner)
+
+    # 대상 주자 활성화
+    password = generate_password()
+    target.password = password
+    target.status = 'active'
+
+    db.session.commit()
+    session.pop('runner_id', None)
+    if swapped:
+        flash(f'{target.name}님과 순서를 바꿨습니다. 다시 차례가 오면 새 문제가 출제됩니다.', 'info')
+    else:
+        flash(f'{target.name}님과 순서를 바꿨습니다. (스페어 부족: 동일 문제 유지)', 'warning')
     return redirect(url_for('index'))
 
 

--- a/templates/_admin_groups.html
+++ b/templates/_admin_groups.html
@@ -129,9 +129,11 @@
                                     data-action="{{ url_for('admin_pass', runner_id=runner.id) }}"
                                     data-label="PASS" data-runner-name="{{ runner.name }}"
                                     data-reason-required="1">PASS</button>
-                            <button class="btn btn-outline-primary btn-sm js-action"
-                                    data-action="{{ url_for('admin_defer', runner_id=runner.id) }}"
-                                    data-label="뒤로 미루기" data-runner-name="{{ runner.name }}">뒤로</button>
+                            <button class="btn btn-outline-primary btn-sm js-defer"
+                                    data-runner-id="{{ runner.id }}"
+                                    data-runner-name="{{ runner.name }}"
+                                    data-current-order="{{ runner.run_order }}"
+                                    data-candidates='{{ defer_candidates.get(runner.id, []) | tojson }}'>뒤로/교환</button>
                             <button class="btn btn-outline-warning btn-sm js-action"
                                     data-action="{{ url_for('admin_skip', runner_id=runner.id) }}"
                                     data-label="건너뛰기" data-runner-name="{{ runner.name }}"

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -148,6 +148,50 @@
   </div>
 </div>
 
+<!-- 미루기/교환 모달 -->
+<div class="modal fade" id="deferModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content" style="background: var(--card-bg, #fff); color: var(--text-primary, #000);">
+      <div class="modal-header">
+        <h5 class="modal-title">미루기 / 순서 변경 — <span id="deferModalName"></span></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        <p style="font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.75rem;">
+          현재 순서: <strong id="deferModalCurrent"></strong>번
+          · 본인 뒤 대기 주자: <strong id="deferModalCount"></strong>명
+        </p>
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="radio" name="deferModalMode" id="deferModeMax" value="max" checked>
+          <label class="form-check-label" for="deferModeMax">조 맨 뒤로</label>
+        </div>
+        <div class="form-check mb-2 d-flex align-items-center gap-2">
+          <input class="form-check-input" type="radio" name="deferModalMode" id="deferModeSteps" value="steps">
+          <label class="form-check-label" for="deferModeSteps" style="margin-right: 0.5rem;">N칸 뒤로</label>
+          <input type="number" id="deferStepsInput" class="form-control form-control-sm"
+                 style="width: 90px;" min="1" max="1" value="1" disabled>
+          <span id="deferStepsHint" style="font-size: 0.8rem; color: var(--text-secondary);"></span>
+        </div>
+        <div class="form-check mb-3">
+          <input class="form-check-input" type="radio" name="deferModalMode" id="deferModeSwap" value="swap">
+          <label class="form-check-label" for="deferModeSwap" style="margin-right: 0.5rem;">특정 주자와 교환</label>
+          <select id="deferSwapSelect" class="form-select form-select-sm mt-1" style="max-width: 320px;" disabled>
+            <option value="">주자 선택...</option>
+          </select>
+        </div>
+        <div>
+          <label class="form-label" style="font-size: 0.85rem;">사유 (선택, 최대 100자)</label>
+          <input type="text" id="deferModalReason" class="form-control form-control-sm" maxlength="100">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="deferModalConfirm">실행</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Reason 입력 모달 -->
 <div class="modal fade" id="reasonModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
@@ -231,6 +275,110 @@
         modal.hide();
         pendingUrl = null;
         if (url) postAction(url, reason);
+    });
+
+    // ---------- 미루기/교환 모달 ----------
+    const deferModalEl = document.getElementById('deferModal');
+    const deferModal = new bootstrap.Modal(deferModalEl);
+    let deferTargetRunnerId = null;
+
+    const dRadioMax = document.getElementById('deferModeMax');
+    const dRadioSteps = document.getElementById('deferModeSteps');
+    const dRadioSwap = document.getElementById('deferModeSwap');
+    const dStepsInput = document.getElementById('deferStepsInput');
+    const dStepsHint = document.getElementById('deferStepsHint');
+    const dSwapSelect = document.getElementById('deferSwapSelect');
+    const dReason = document.getElementById('deferModalReason');
+
+    function syncDeferModeInputs() {
+        const mode = document.querySelector('input[name="deferModalMode"]:checked').value;
+        dStepsInput.disabled = mode !== 'steps';
+        dSwapSelect.disabled = mode !== 'swap';
+    }
+    [dRadioMax, dRadioSteps, dRadioSwap].forEach(r => r.addEventListener('change', syncDeferModeInputs));
+
+    document.addEventListener('click', (ev) => {
+        const btn = ev.target.closest('.js-defer');
+        if (!btn) return;
+        ev.preventDefault();
+        deferTargetRunnerId = btn.dataset.runnerId;
+        const name = btn.dataset.runnerName || '';
+        const currentOrder = parseInt(btn.dataset.currentOrder, 10);
+        let candidates = [];
+        try { candidates = JSON.parse(btn.dataset.candidates || '[]'); } catch (e) { candidates = []; }
+
+        document.getElementById('deferModalName').textContent = name;
+        document.getElementById('deferModalCurrent').textContent = currentOrder;
+        document.getElementById('deferModalCount').textContent = candidates.length;
+
+        const maxSteps = candidates.length;
+        dStepsInput.max = Math.max(1, maxSteps);
+        dStepsInput.value = 1;
+        dStepsHint.textContent = '(1 ~ ' + maxSteps + ')';
+
+        dSwapSelect.innerHTML = '<option value="">주자 선택...</option>';
+        for (const c of candidates) {
+            const opt = document.createElement('option');
+            opt.value = c.order;
+            opt.textContent = c.order + '번 · ' + c.name + ' (' + c.knox_id + ')';
+            dSwapSelect.appendChild(opt);
+        }
+
+        dRadioMax.checked = true;
+        syncDeferModeInputs();
+        dReason.value = '';
+        if (maxSteps === 0) {
+            alert('이미 마지막 주자입니다.');
+            return;
+        }
+        deferModal.show();
+    });
+
+    document.getElementById('deferModalConfirm').addEventListener('click', async () => {
+        if (!deferTargetRunnerId) return;
+        const mode = document.querySelector('input[name="deferModalMode"]:checked').value;
+        const body = new URLSearchParams();
+        body.append('mode', mode);
+        body.append('reason', dReason.value.trim());
+        if (mode === 'steps') {
+            const s = parseInt(dStepsInput.value, 10);
+            const max = parseInt(dStepsInput.max, 10);
+            if (!s || s < 1 || s > max) {
+                alert('이동 칸 수는 1~' + max + ' 사이로 입력하세요.');
+                return;
+            }
+            body.append('steps', s);
+        } else if (mode === 'swap') {
+            if (!dSwapSelect.value) {
+                alert('교환할 주자를 선택하세요.');
+                return;
+            }
+            body.append('target_order', dSwapSelect.value);
+        }
+
+        const url = '/admin/defer/' + deferTargetRunnerId;
+        deferModal.hide();
+        actionInFlight = true;
+        statusEl.textContent = '처리 중...';
+        try {
+            const res = await fetch(url, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'Accept': 'application/json',
+                },
+                body: body.toString(),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) throw new Error(data.message || ('HTTP ' + res.status));
+        } catch (e) {
+            alert('실패: ' + e.message);
+        } finally {
+            actionInFlight = false;
+            await refreshPartial();
+        }
     });
 
     // 버튼 이벤트 위임 (partial이 바뀌어도 작동)

--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -72,16 +72,30 @@
         <!-- 미루기 -->
         <div class="card mt-4">
             <div class="card-body py-3">
-                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-                    <div style="font-size: 0.9rem; color: var(--text-secondary);">
-                        막혔거나 당장 풀기 어렵다면 내 차례를 조 맨 뒤로 미룰 수 있습니다.
-                        (다음 주자에게 먼저 기회가 넘어가고, 나중에 다시 시도 가능)
-                    </div>
+                <div style="font-size: 0.9rem; color: var(--text-secondary); margin-bottom: 0.75rem;">
+                    막혔거나 당장 풀기 어렵다면 본인 차례를 미룰 수 있습니다.
+                    미룰 때마다 새 문제로 교체되며 차례가 다시 돌아오면 재로그인 해야 합니다.
+                </div>
+                <div class="d-flex flex-wrap gap-2">
                     <form method="POST" action="{{ url_for('defer') }}"
                           onsubmit="return deferConfirm(event);" class="d-inline">
                         <input type="hidden" name="reason" id="deferReasonField" value="">
-                        <button type="submit" class="btn btn-outline-primary btn-sm">내 차례 뒤로 미루기</button>
+                        <button type="submit" class="btn btn-outline-primary btn-sm">내 차례 맨 뒤로 미루기</button>
                     </form>
+
+                    {% if swap_candidates %}
+                    <form method="POST" action="{{ url_for('defer_swap') }}"
+                          onsubmit="return swapConfirm(event);" class="d-inline d-flex flex-wrap gap-2">
+                        <input type="hidden" name="reason" id="swapReasonField" value="">
+                        <select name="target_order" class="form-select form-select-sm" style="max-width: 280px;" required>
+                            <option value="">특정 주자와 순서 교환...</option>
+                            {% for c in swap_candidates %}
+                            <option value="{{ c.run_order }}">{{ c.run_order }}번 · {{ c.name }} ({{ c.knox_id }})</option>
+                            {% endfor %}
+                        </select>
+                        <button type="submit" class="btn btn-outline-primary btn-sm">교환</button>
+                    </form>
+                    {% endif %}
                 </div>
             </div>
         </div>
@@ -102,6 +116,28 @@ function deferConfirm(ev) {
         return false;
     }
     document.getElementById('deferReasonField').value = (reason || '').slice(0, 100);
+    return true;
+}
+
+function swapConfirm(ev) {
+    const form = ev.target;
+    const sel = form.querySelector('select[name="target_order"]');
+    if (!sel.value) {
+        alert('교환할 주자를 선택하세요.');
+        ev.preventDefault();
+        return false;
+    }
+    const text = sel.options[sel.selectedIndex].text;
+    if (!confirm('정말 ' + text + ' 와(과) 순서를 교환하시겠습니까?\n로그아웃되며, 차례가 다시 돌아오면 재로그인 해야 합니다.')) {
+        ev.preventDefault();
+        return false;
+    }
+    const reason = prompt('사유를 간단히 적어주세요 (선택, 최대 100자):', '');
+    if (reason === null) {
+        ev.preventDefault();
+        return false;
+    }
+    document.getElementById('swapReasonField').value = (reason || '').slice(0, 100);
     return true;
 }
 </script>

--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -76,16 +76,20 @@
                     막혔거나 당장 풀기 어렵다면 본인 차례를 미룰 수 있습니다.
                     미룰 때마다 새 문제로 교체되며 차례가 다시 돌아오면 재로그인 해야 합니다.
                 </div>
-                <div class="d-flex flex-wrap gap-2">
+                {% if swap_candidates %}
+                <div class="d-flex flex-wrap gap-3 align-items-start">
                     <form method="POST" action="{{ url_for('defer') }}"
-                          onsubmit="return deferConfirm(event);" class="d-inline">
+                          onsubmit="return deferConfirm(event);" class="d-flex flex-wrap gap-2 align-items-center">
                         <input type="hidden" name="reason" id="deferReasonField" value="">
-                        <button type="submit" class="btn btn-outline-primary btn-sm">내 차례 맨 뒤로 미루기</button>
+                        <input type="number" name="steps" min="1" max="{{ swap_candidates|length }}"
+                               value="1" class="form-control form-control-sm" style="max-width: 80px;" required>
+                        <button type="submit" class="btn btn-outline-primary btn-sm">
+                            칸 뒤로 이동 (최대 {{ swap_candidates|length }})
+                        </button>
                     </form>
 
-                    {% if swap_candidates %}
                     <form method="POST" action="{{ url_for('defer_swap') }}"
-                          onsubmit="return swapConfirm(event);" class="d-inline d-flex flex-wrap gap-2">
+                          onsubmit="return swapConfirm(event);" class="d-flex flex-wrap gap-2 align-items-center">
                         <input type="hidden" name="reason" id="swapReasonField" value="">
                         <select name="target_order" class="form-select form-select-sm" style="max-width: 280px;" required>
                             <option value="">특정 주자와 순서 교환...</option>
@@ -95,8 +99,12 @@
                         </select>
                         <button type="submit" class="btn btn-outline-primary btn-sm">교환</button>
                     </form>
-                    {% endif %}
                 </div>
+                {% else %}
+                <div style="color: var(--text-secondary); font-size: 0.85rem;">
+                    조 마지막 주자라 더 이상 미룰 수 없습니다.
+                </div>
+                {% endif %}
             </div>
         </div>
     </div>
@@ -106,7 +114,18 @@
 {% block scripts %}
 <script>
 function deferConfirm(ev) {
-    if (!confirm('정말 본인의 차례를 조의 맨 뒤로 미루시겠습니까?\n로그아웃되며, 차례가 다시 돌아오면 재로그인 해야 합니다.')) {
+    const form = ev.target;
+    const stepsInput = form.querySelector('input[name="steps"]');
+    const steps = parseInt(stepsInput.value, 10);
+    const max = parseInt(stepsInput.max, 10);
+    if (!steps || steps < 1 || steps > max) {
+        alert('이동 칸 수를 1~' + max + ' 사이로 입력하세요.');
+        ev.preventDefault();
+        return false;
+    }
+    const msg = (steps === max ? '맨 뒤로 이동' : steps + '칸 뒤로 이동') +
+        '하시겠습니까?\n로그아웃되며, 차례가 다시 돌아오면 재로그인 해야 합니다.';
+    if (!confirm(msg)) {
         ev.preventDefault();
         return false;
     }

--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -125,7 +125,8 @@ function deferConfirm(ev) {
         return false;
     }
     const msg = (steps === max ? '맨 뒤로 이동' : steps + '칸 뒤로 이동') +
-        '하시겠습니까?\n로그아웃되며, 차례가 다시 돌아오면 재로그인 해야 합니다.';
+        '하시겠습니까?\n다음 주자에게 전달할 비밀번호가 표시됩니다. ' +
+        '차례가 다시 돌아오면 재로그인 해야 합니다.';
     if (!confirm(msg)) {
         ev.preventDefault();
         return false;
@@ -148,7 +149,8 @@ function swapConfirm(ev) {
         return false;
     }
     const text = sel.options[sel.selectedIndex].text;
-    if (!confirm('정말 ' + text + ' 와(과) 순서를 교환하시겠습니까?\n로그아웃되며, 차례가 다시 돌아오면 재로그인 해야 합니다.')) {
+    if (!confirm('정말 ' + text + ' 와(과) 순서를 교환하시겠습니까?\n' +
+        '다음 주자에게 전달할 비밀번호가 표시됩니다. 차례가 다시 돌아오면 재로그인 해야 합니다.')) {
         ev.preventDefault();
         return false;
     }

--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -74,7 +74,8 @@
             <div class="card-body py-3">
                 <div style="font-size: 0.9rem; color: var(--text-secondary); margin-bottom: 0.75rem;">
                     막혔거나 당장 풀기 어렵다면 본인 차례를 미룰 수 있습니다.
-                    미룰 때마다 새 문제로 교체되며 차례가 다시 돌아오면 재로그인 해야 합니다.
+                    미룰 때마다 새 문제로 교체되며 차례가 다시 돌아오면 재로그인 해야 합니다.<br>
+                    <span style="color: var(--accent-yellow);">※ 특정 주자와 순서 교환은 해당 주자와 사전에 협의 후 진행하세요.</span>
                 </div>
                 {% if swap_candidates %}
                 <div class="d-flex flex-wrap gap-3 align-items-start">

--- a/templates/defer_result.html
+++ b/templates/defer_result.html
@@ -56,6 +56,15 @@
                         <li>다음 주자가 사이트에 접속하여 문제를 풀 수 있도록 안내</li>
                     </ol>
                 </div>
+
+                <div class="mt-3 p-3" style="background: rgba(239,68,68,0.08); border: 1px solid rgba(239,68,68,0.35); border-radius: 12px;">
+                    <h6 style="font-weight: 700; color: #ef4444; margin-bottom: 0.4rem;">⚠ 비밀번호 취급 주의</h6>
+                    <ul style="color: var(--text-secondary); font-size: 0.85rem; margin-bottom: 0; padding-left: 1.2rem;">
+                        <li>위 비밀번호는 <strong>{{ new_active.name }}님 전용</strong>입니다. <strong>본인이 사용하거나 다른 사람에게 공유하지 마세요.</strong></li>
+                        <li>다음 주자에게 즉시 전달한 뒤 이 화면을 닫으시고, 본인 차례가 다시 돌아오면 그때 새 비밀번호를 받아 재로그인하세요.</li>
+                        <li>비밀번호 오용 시 시스템 로그(로그인 IP·시각·시도 횟수)로 사후 적발될 수 있습니다.</li>
+                    </ul>
+                </div>
             </div>
         </div>
         {% else %}

--- a/templates/defer_result.html
+++ b/templates/defer_result.html
@@ -57,12 +57,11 @@
                     </ol>
                 </div>
 
-                <div class="mt-3 p-3" style="background: rgba(239,68,68,0.08); border: 1px solid rgba(239,68,68,0.35); border-radius: 12px;">
-                    <h6 style="font-weight: 700; color: #ef4444; margin-bottom: 0.4rem;">⚠ 비밀번호 취급 주의</h6>
+                <div class="mt-3 p-3" style="background: rgba(65,105,225,0.08); border: 1px solid rgba(65,105,225,0.3); border-radius: 12px;">
+                    <h6 style="font-weight: 700; color: var(--samsung-blue-light); margin-bottom: 0.4rem;">💡 비밀번호 안내</h6>
                     <ul style="color: var(--text-secondary); font-size: 0.85rem; margin-bottom: 0; padding-left: 1.2rem;">
-                        <li>위 비밀번호는 <strong>{{ new_active.name }}님 전용</strong>입니다. <strong>본인이 사용하거나 다른 사람에게 공유하지 마세요.</strong></li>
-                        <li>다음 주자에게 즉시 전달한 뒤 이 화면을 닫으시고, 본인 차례가 다시 돌아오면 그때 새 비밀번호를 받아 재로그인하세요.</li>
-                        <li>비밀번호 오용 시 시스템 로그(로그인 IP·시각·시도 횟수)로 사후 적발될 수 있습니다.</li>
+                        <li>위 비밀번호는 <strong>{{ new_active.name }}님</strong>께만 전달해 주세요.</li>
+                        <li>본인 차례가 다시 돌아오면 그때 새 비밀번호를 받아 재로그인하면 됩니다.</li>
                     </ul>
                 </div>
             </div>

--- a/templates/defer_result.html
+++ b/templates/defer_result.html
@@ -1,0 +1,88 @@
+{% extends "base.html" %}
+
+{% block title %}순서 변경 완료{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-lg-7">
+
+        <!-- 결과 메시지 -->
+        <div class="text-center mb-4">
+            <div style="font-size: 3rem;">↪️</div>
+            <h2 style="font-weight: 800; margin-top: 1rem;">순서가 변경되었습니다</h2>
+            <p style="color: var(--text-secondary);">
+                {{ runner.name }} ({{ runner.group.name }}) — 새 순서: {{ runner.run_order }}번
+            </p>
+            <p style="color: var(--accent-yellow); font-size: 0.9rem; margin-top: 0.5rem;">
+                차례가 다시 돌아오면 <strong>새 문제</strong>가 출제됩니다.
+            </p>
+        </div>
+
+        {% if new_active %}
+        <!-- 다음 주자 정보 -->
+        <div class="card mb-4">
+            <div class="card-header py-3 text-center">
+                <h5 class="mb-0" style="font-weight: 700;">새로 활성화된 주자에게 비밀번호를 전달하세요</h5>
+            </div>
+            <div class="card-body">
+                <div class="text-center mb-3">
+                    <p style="color: var(--text-secondary); margin-bottom: 0.3rem;">다음 주자</p>
+                    <p style="font-size: 1.3rem; font-weight: 700;">
+                        {{ new_active.name }}
+                    </p>
+                    <p style="color: var(--text-secondary); font-size: 0.9rem;">
+                        Knox ID: <strong style="color: var(--text-primary);">{{ new_active.knox_id }}</strong>
+                    </p>
+                    <p style="color: var(--text-secondary); font-size: 0.85rem;">
+                        {{ runner.group.name }} · {{ new_active.run_order }}번째 주자
+                    </p>
+                </div>
+
+                <div class="password-display">
+                    <p style="color: var(--text-secondary); margin-bottom: 0.5rem; font-size: 0.9rem;">
+                        다음 주자의 접속 비밀번호
+                    </p>
+                    <div class="password-value" id="next-password">{{ next_password }}</div>
+                    <button class="btn btn-outline-success btn-sm mt-3" onclick="copyPassword()">
+                        비밀번호 복사
+                    </button>
+                </div>
+
+                <div class="mt-4 p-3" style="background: rgba(255,255,255,0.03); border-radius: 12px;">
+                    <h6 style="font-weight: 700; color: var(--accent-yellow);">다음 단계</h6>
+                    <ol style="color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 0;">
+                        <li>다음 주자 <strong>{{ new_active.name }}</strong>에게 연락</li>
+                        <li>위 <strong>Knox ID</strong>와 <strong>접속 비밀번호</strong>를 전달</li>
+                        <li>다음 주자가 사이트에 접속하여 문제를 풀 수 있도록 안내</li>
+                    </ol>
+                </div>
+            </div>
+        </div>
+        {% else %}
+        <div class="card mb-4">
+            <div class="card-body text-center" style="color: var(--text-secondary);">
+                활성화된 다음 주자가 없습니다.
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="text-center">
+            <a href="{{ url_for('logout') }}" class="btn btn-samsung">로그아웃</a>
+            <a href="{{ url_for('leaderboard') }}" class="btn btn-outline-secondary ms-2">리더보드 보기</a>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function copyPassword() {
+    const pw = document.getElementById('next-password').textContent.trim();
+    navigator.clipboard.writeText(pw).then(() => {
+        const btn = event.target;
+        btn.textContent = '복사 완료!';
+        setTimeout(() => btn.textContent = '비밀번호 복사', 2000);
+    });
+}
+</script>
+{% endblock %}

--- a/templates/success.html
+++ b/templates/success.html
@@ -72,6 +72,11 @@
                         <li>다음 주자가 사이트에 접속하여 문제를 풀 수 있도록 안내하세요</li>
                     </ol>
                 </div>
+
+                <div class="mt-3" style="font-size: 0.85rem; color: var(--text-secondary);">
+                    ※ 비밀번호는 다음 주자 <strong>{{ next_runner.name }}</strong>님 전용입니다.
+                    본인이 사용하거나 다른 사람에게 공유하지 마세요.
+                </div>
             </div>
         </div>
         {% endif %}


### PR DESCRIPTION
Closes #37

## 요약
기존 \"맨 뒤로 미루기\"에 더해, 같은 조의 미진행 특정 주자와 1:1 순서 교환 가능.

## 변경
- POST /defer/swap 라우트
- /challenge 라우트가 swap_candidates(같은 조, 본인 뒤, status=waiting) 전달
- challenge.html: 셀렉트박스 + 교환 버튼 + confirm 모달

## 동작
- 본인은 waiting + run_order=대상의 원래 순서 + deferred_count++ + 새 문제 + 리셋
- 대상은 active + 본인의 원래 순서 + 비밀번호 발급
- 중간 순서 주자(가령 1↔5 교환 시 2,3,4번)는 영향 없음

## 검증
- 1번 ↔ 5번 교환 → 1번 (run_order=5, waiting, deferred=1), 5번 (run_order=1, active, pw 발급) ✓
- 2/3/4번 status 변화 없음 ✓
- swap_candidates에 본인보다 앞 또는 비-waiting 주자는 안 뜸 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)