### PR TITLE
관리자: 대기 주자 순서 양방향 재배치

### DIFF
--- a/app.py
+++ b/app.py
@@ -731,12 +731,20 @@ def admin_dashboard():
     reviews = Runner.query.filter(Runner.review.isnot(None))\
         .order_by(Runner.review_submitted_at.desc()).all()
 
-    # 미루기 모달용: 각 주자별 교환 후보 (같은 조 + 본인 뒤 + waiting)
+    # 미루기/순서변경 모달용: 각 주자별 후보
+    # - active: 같은 조 + 본인 뒤 + waiting (뒤로 한정)
+    # - waiting: 같은 조 + 자신 외 모든 waiting (양방향)
     defer_candidates = {}
     for r in all_runners:
-        if r.status in ('waiting', 'active'):
+        if r.status == 'active':
             cands = [c for c in grouped[r.group_id]
                      if c.status == 'waiting' and c.run_order > r.run_order]
+        elif r.status == 'waiting':
+            cands = [c for c in grouped[r.group_id]
+                     if c.status == 'waiting' and c.id != r.id]
+        else:
+            cands = []
+        if r.status in ('waiting', 'active'):
             defer_candidates[r.id] = [
                 {'order': c.run_order, 'name': c.name, 'knox_id': c.knox_id}
                 for c in cands
@@ -825,7 +833,37 @@ def admin_defer(runner_id):
     mode = request.form.get('mode', 'max')
     reason = request.form.get('reason', '').strip()[:200]
 
-    # ---- swap 모드 ----
+    # ---- reorder_swap 모드: 대기 주자 간 양방향 순서 교환 (패널티/문제 교체 없음) ----
+    if mode == 'reorder_swap':
+        if runner.status != 'waiting':
+            msg = '대기 중 주자만 reorder_swap 가능 (active 주자는 swap 사용).'
+            if _is_ajax():
+                return jsonify({'ok': False, 'message': msg}), 400
+            flash(msg, 'warning')
+            return redirect(url_for('admin_dashboard'))
+        try:
+            target_order = int(request.form.get('target_order', 0))
+        except (TypeError, ValueError):
+            target_order = 0
+        target = Runner.query.filter_by(
+            group_id=runner.group_id, run_order=target_order, status='waiting',
+        ).first()
+        if not target or target.id == runner.id:
+            msg = '교환 대상은 같은 조의 다른 대기 주자여야 합니다.'
+            if _is_ajax():
+                return jsonify({'ok': False, 'message': msg}), 400
+            flash(msg, 'warning')
+            return redirect(url_for('admin_dashboard'))
+        # 순서만 swap — 상태·문제·시작시각·deferred_count 모두 그대로
+        runner.run_order, target.run_order = target.run_order, runner.run_order
+        runner.reason = reason or None
+        db.session.commit()
+        if _is_ajax():
+            return jsonify({'ok': True, 'reordered': True})
+        flash(f'{runner.name} ↔ {target.name} 순서 교환 완료', 'info')
+        return redirect(url_for('admin_dashboard'))
+
+    # ---- swap 모드 (active 주자, 뒤로 한정) ----
     if mode == 'swap':
         try:
             target_order = int(request.form.get('target_order', 0))
@@ -949,9 +987,15 @@ def admin_partial_groups():
     total_runners = sum(r['total'] for r in rankings)
     defer_candidates = {}
     for r in all_runners:
-        if r.status in ('waiting', 'active'):
+        if r.status == 'active':
             cands = [c for c in grouped[r.group_id]
                      if c.status == 'waiting' and c.run_order > r.run_order]
+        elif r.status == 'waiting':
+            cands = [c for c in grouped[r.group_id]
+                     if c.status == 'waiting' and c.id != r.id]
+        else:
+            cands = []
+        if r.status in ('waiting', 'active'):
             defer_candidates[r.id] = [
                 {'order': c.run_order, 'name': c.name, 'knox_id': c.knox_id}
                 for c in cands

--- a/templates/_admin_groups.html
+++ b/templates/_admin_groups.html
@@ -132,8 +132,9 @@
                             <button class="btn btn-outline-primary btn-sm js-defer"
                                     data-runner-id="{{ runner.id }}"
                                     data-runner-name="{{ runner.name }}"
+                                    data-runner-status="{{ runner.status }}"
                                     data-current-order="{{ runner.run_order }}"
-                                    data-candidates='{{ defer_candidates.get(runner.id, []) | tojson }}'>뒤로/교환</button>
+                                    data-candidates='{{ defer_candidates.get(runner.id, []) | tojson }}'>{% if runner.status == 'active' %}뒤로/교환{% else %}순서 변경{% endif %}</button>
                             <button class="btn btn-outline-warning btn-sm js-action"
                                     data-action="{{ url_for('admin_skip', runner_id=runner.id) }}"
                                     data-label="건너뛰기" data-runner-name="{{ runner.name }}"

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -153,13 +153,19 @@
   <div class="modal-dialog">
     <div class="modal-content" style="background: var(--card-bg, #fff); color: var(--text-primary, #000);">
       <div class="modal-header">
-        <h5 class="modal-title">미루기 / 순서 변경 — <span id="deferModalName"></span></h5>
+        <h5 class="modal-title"><span id="deferTitleSuffix">미루기 / 순서 변경</span> — <span id="deferModalName"></span></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
       </div>
       <div class="modal-body">
-        <p style="font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.75rem;">
+        <p style="font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.5rem;">
           현재 순서: <strong id="deferModalCurrent"></strong>번
-          · 본인 뒤 대기 주자: <strong id="deferModalCount"></strong>명
+          · 교환 가능 주자: <strong id="deferModalCount"></strong>명
+        </p>
+        <p id="deferActiveNote" style="font-size: 0.8rem; color: var(--text-secondary); margin-bottom: 0.75rem;">
+          ※ active 주자 — 미루기 시 패널티(deferred_count++) + 새 문제 교체가 적용됩니다.
+        </p>
+        <p id="deferWaitingNote" style="font-size: 0.8rem; color: var(--accent-green); margin-bottom: 0.75rem; display: none;">
+          ※ 대기 주자 — 단순 순서 교환 (패널티/문제 교체 없음, 양방향 가능).
         </p>
         <div class="form-check mb-2">
           <input class="form-check-input" type="radio" name="deferModalMode" id="deferModeMax" value="max" checked>
@@ -303,6 +309,7 @@
         ev.preventDefault();
         deferTargetRunnerId = btn.dataset.runnerId;
         const name = btn.dataset.runnerName || '';
+        const status = btn.dataset.runnerStatus || 'active';
         const currentOrder = parseInt(btn.dataset.currentOrder, 10);
         let candidates = [];
         try { candidates = JSON.parse(btn.dataset.candidates || '[]'); } catch (e) { candidates = []; }
@@ -311,10 +318,25 @@
         document.getElementById('deferModalCurrent').textContent = currentOrder;
         document.getElementById('deferModalCount').textContent = candidates.length;
 
-        const maxSteps = candidates.length;
-        dStepsInput.max = Math.max(1, maxSteps);
-        dStepsInput.value = 1;
-        dStepsHint.textContent = '(1 ~ ' + maxSteps + ')';
+        // status별 옵션 노출/숨김 — active는 3개, waiting은 swap만
+        const isActive = (status === 'active');
+        document.getElementById('deferModeMax').parentElement.style.display = isActive ? '' : 'none';
+        document.getElementById('deferModeSteps').parentElement.parentElement.style.display = isActive ? '' : 'none';
+        document.getElementById('deferTitleSuffix').textContent = isActive ? '미루기 / 순서 변경' : '대기 주자 순서 변경';
+        document.getElementById('deferActiveNote').style.display = isActive ? '' : 'none';
+        document.getElementById('deferWaitingNote').style.display = isActive ? 'none' : '';
+
+        if (isActive) {
+            const maxSteps = candidates.length;
+            dStepsInput.max = Math.max(1, maxSteps);
+            dStepsInput.value = 1;
+            dStepsHint.textContent = '(1 ~ ' + maxSteps + ')';
+            dRadioMax.checked = true;
+        } else {
+            // waiting → swap 모드 강제
+            dRadioSwap.checked = true;
+        }
+        syncDeferModeInputs();
 
         dSwapSelect.innerHTML = '<option value="">주자 선택...</option>';
         for (const c of candidates) {
@@ -323,12 +345,12 @@
             opt.textContent = c.order + '번 · ' + c.name + ' (' + c.knox_id + ')';
             dSwapSelect.appendChild(opt);
         }
+        // waiting일 때는 swap 셀렉트 항상 enable
+        if (!isActive) dSwapSelect.disabled = false;
 
-        dRadioMax.checked = true;
-        syncDeferModeInputs();
         dReason.value = '';
-        if (maxSteps === 0) {
-            alert('이미 마지막 주자입니다.');
+        if (candidates.length === 0) {
+            alert(isActive ? '이미 마지막 주자입니다.' : '교환할 다른 대기 주자가 없습니다.');
             return;
         }
         deferModal.show();
@@ -336,7 +358,12 @@
 
     document.getElementById('deferModalConfirm').addEventListener('click', async () => {
         if (!deferTargetRunnerId) return;
-        const mode = document.querySelector('input[name="deferModalMode"]:checked').value;
+        const btn = document.querySelector(`.js-defer[data-runner-id="${deferTargetRunnerId}"]`);
+        const status = (btn && btn.dataset.runnerStatus) || 'active';
+        let mode = document.querySelector('input[name="deferModalMode"]:checked').value;
+        // waiting 주자는 swap만 가능 — reorder_swap 모드로 전환
+        if (status === 'waiting') mode = 'reorder_swap';
+
         const body = new URLSearchParams();
         body.append('mode', mode);
         body.append('reason', dReason.value.trim());
@@ -348,7 +375,7 @@
                 return;
             }
             body.append('steps', s);
-        } else if (mode === 'swap') {
+        } else if (mode === 'swap' || mode === 'reorder_swap') {
             if (!dSwapSelect.value) {
                 alert('교환할 주자를 선택하세요.');
                 return;


### PR DESCRIPTION
Closes #39

## 요약
관리자가 대기 중인 주자의 순서를 패널티/문제 교체 없이 양방향 swap할 수 있게 한다.

## 변경
- POST /admin/defer/<id> 에 mode='reorder_swap' 추가
- 대기 주자 ↔ 대기 주자, 순서만 교환 (status/문제/시작시각/deferred_count 보존)
- defer_candidates: active(뒤로 + waiting) vs waiting(전체 다른 waiting) 분기
- 모달 status별 옵션 분기:
  - active: 맨 뒤로 / N칸 / 교환 (3옵션, 패널티 적용)
  - waiting: 교환만 (양방향, 패널티 없음)
- 버튼 라벨: '뒤로/교환' (active) / '순서 변경' (waiting)

## 검증
- waiting 5번 ↔ waiting 9번 reorder_swap → 둘 다 deferred_count=0 유지, 문제 텍스트 그대로 ✓
- active 주자에 reorder_swap 요청 → 400 거부 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)